### PR TITLE
UI/account manager refresh

### DIFF
--- a/Skua.Core.Models/Servers/Server.cs
+++ b/Skua.Core.Models/Servers/Server.cs
@@ -64,6 +64,12 @@ public class Server
     [JsonProperty("iLevel")]
     public int Level { get; set; }
 
+    /// <summary>
+    /// The ping/latency to this server in milliseconds (calculated client-side).
+    /// </summary>
+    [JsonIgnore]
+    public long Ping { get; set; } = -1;
+
     public override string ToString()
     {
         return $"{Name} - {PlayerCount}";

--- a/Skua.Core.Models/SettingsModels.cs
+++ b/Skua.Core.Models/SettingsModels.cs
@@ -16,6 +16,15 @@ public class AccountData
     public List<string> Tags { get; set; } = new();
 }
 
+public class GroupData
+{
+    [JsonPropertyName("Name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("Accounts")]
+    public List<string> Accounts { get; set; } = new();
+}
+
 public class AccountDataDictionaryJsonConverter : JsonConverter<Dictionary<string, AccountData>>
 {
     private const string LegacySeparator = "{=}";
@@ -284,6 +293,9 @@ public class ManagerSettings
     [JsonPropertyName("ManagedAccounts")]
     [JsonConverter(typeof(AccountDataDictionaryJsonConverter))]
     public Dictionary<string, AccountData> ManagedAccounts { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    [JsonPropertyName("AccountGroups")]
+    public List<GroupData>? AccountGroups { get; set; } = new();
 
     [JsonPropertyName("LastServer")]
     public string LastServer { get; set; } = string.Empty;

--- a/Skua.Core/Compiler.cs
+++ b/Skua.Core/Compiler.cs
@@ -266,7 +266,7 @@ public class Compiler : CSharpScriptExecution
             return source;
 
         int currentHash = Namespaces.Count > 0 ? string.Join(";", Namespaces).GetHashCode() : 0;
-        
+
         lock (_namespaceCacheLock)
         {
             if (_cachedNamespacePrefix == null || _lastNamespaceHash != currentHash)

--- a/Skua.Core/Messaging/ManagerMesssages.cs
+++ b/Skua.Core/Messaging/ManagerMesssages.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.Messaging.Messages;
 using Skua.Core.Models.GitHub;
 using Skua.Core.ViewModels;
+using Skua.Core.ViewModels.Manager;
 
 namespace Skua.Core.Messaging;
 
@@ -15,3 +16,10 @@ public sealed record UpdateFinishedMessage();
 public sealed record ClearPasswordBoxMessage();
 public sealed record RemoveAccountMessage(AccountItemViewModel Account);
 public sealed record AccountSelectedMessage(bool Add);
+public sealed record AddAccountToGroupMessage(AccountItemViewModel Account);
+public sealed record AddTagsMessage(AccountItemViewModel Account);
+public sealed record StartAccountMessage(AccountItemViewModel Account, bool WithScript);
+public sealed record RemoveGroupMessage(GroupItemViewModel Group);
+public sealed record StartGroupMessage(GroupItemViewModel Group, bool WithScript);
+public sealed record RenameGroupMessage(GroupItemViewModel Group);
+public sealed record RemoveAccountFromGroupMessage(GroupItemViewModel Group, AccountItemViewModel Account);

--- a/Skua.Core/ScriptLoadContext.cs
+++ b/Skua.Core/ScriptLoadContext.cs
@@ -41,7 +41,7 @@ public class ScriptLoadContext : AssemblyLoadContext
         if (matchingFiles.Length > 0)
         {
             string latestFile = matchingFiles.OrderByDescending(f => File.GetLastWriteTimeUtc(f)).First();
-            
+
             if (!File.Exists(latestFile))
                 return null;
 

--- a/Skua.Core/Scripts/ScriptManager.cs
+++ b/Skua.Core/Scripts/ScriptManager.cs
@@ -104,17 +104,17 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
             object? script = await Task.Run(() => Compile(scriptContent));
 
             LoadScriptConfig(script);
-            
+
             bool needsConfig;
             lock (_configuredLock)
             {
                 needsConfig = _configured.TryGetValue(Config!.Storage, out bool b) && !b;
             }
-            
+
             ManualResetEventSlim scriptReady = new(false);
 
             Handlers.Clear();
-            
+
             lock (_stateLock)
             {
                 _runScriptStoppingBool = false;
@@ -146,7 +146,7 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
                         Trace.WriteLine($"Error while running script:\r\nMessage: {(e.InnerException is not null ? e.InnerException.Message : e.Message)}\r\nStackTrace: {(e.InnerException is not null ? e.InnerException.StackTrace : e.StackTrace)}");
 
                         StrongReferenceMessenger.Default.Send<ScriptErrorMessage, int>(new(e), (int)MessageChannels.ScriptStatus);
-                        
+
                         lock (_stateLock)
                         {
                             _runScriptStoppingBool = true;
@@ -161,7 +161,7 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
                         _stoppedByScript = false;
                         shouldSendStoppingMessage = _runScriptStoppingBool;
                     }
-                    
+
                     if (shouldSendStoppingMessage)
                     {
                         StrongReferenceMessenger.Default.Send<ScriptStoppingMessage, int>((int)MessageChannels.ScriptStatus);
@@ -260,7 +260,7 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
             _runScriptStoppingBool = runScriptStoppingEvent;
             _stoppedByScript = true;
         }
-        
+
         ScriptCts?.Cancel();
 
         if (Thread.CurrentThread.Name == "Script Thread")
@@ -324,7 +324,7 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
         CheckScriptVersionRequirement(source);
 
         Stopwatch sw = Stopwatch.StartNew();
-        
+
         _includedFilesLock.EnterWriteLock();
         try
         {
@@ -334,7 +334,7 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
         {
             _includedFilesLock.ExitWriteLock();
         }
-        
+
         HashSet<string> references = GetReferences();
         string final = ProcessSources(source, ref references);
 
@@ -403,7 +403,7 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
     private HashSet<string> GetReferences()
     {
         HashSet<string> references = new();
-        
+
         lock (_refCacheLock)
         {
             if (_refCache.Count == 0 && Directory.Exists(ClientFileSources.SkuaPluginsDIR))
@@ -867,7 +867,7 @@ public partial class ScriptManager : ObservableObject, IScriptManager, IDisposab
         {
             _includedFilesLock.ExitReadLock();
         }
-        
+
         List<string> newlyAddedFiles = new();
         foreach (KeyValuePair<string, List<string>> kvp in dependencyGraph)
         {

--- a/Skua.Core/ViewModels/AboutViewModel.cs
+++ b/Skua.Core/ViewModels/AboutViewModel.cs
@@ -31,30 +31,12 @@ public class AboutViewModel : BotControlViewModelBase
 
         try
         {
-            // Handle relative file paths that start with "./"
             if (url.StartsWith("./"))
             {
-                // Get the relative path without the "./" prefix
-                string relativePath = url.Substring(2);
-
-                // Combine with the current directory to get the full path
-                string fullPath = System.IO.Path.Combine(Environment.CurrentDirectory, relativePath);
-
-                // Check if the file exists
-                if (System.IO.File.Exists(fullPath))
-                {
-                    Process.Start(new ProcessStartInfo(fullPath) { UseShellExecute = true });
-                }
-                else
-                {
-                    // If file doesn't exist locally, try to open it from the GitHub repository
-                    string githubUrl = $"https://raw.githubusercontent.com/auqw/Skua/refs/heads/master/{relativePath}";
-                    Process.Start(new ProcessStartInfo(githubUrl) { UseShellExecute = true });
-                }
+                Process.Start(new ProcessStartInfo($"https://github.com/auqw/Skua/blob/master/{url.Substring(2)}") { UseShellExecute = true });
             }
             else
             {
-                // Handle regular URLs
                 Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
             }
         }

--- a/Skua.Core/ViewModels/Manager/AccountItemViewModel.cs
+++ b/Skua.Core/ViewModels/Manager/AccountItemViewModel.cs
@@ -44,4 +44,34 @@ public partial class AccountItemViewModel : ObservableObject
     {
         WeakReferenceMessenger.Default.Send<RemoveAccountMessage>(new(this));
     }
+
+    [RelayCommand]
+    private void AddTags()
+    {
+        WeakReferenceMessenger.Default.Send<AddTagsMessage>(new(this));
+    }
+
+    [RelayCommand]
+    private void Start()
+    {
+        WeakReferenceMessenger.Default.Send<StartAccountMessage>(new(this, false));
+    }
+
+    [RelayCommand]
+    private void StartWithScript()
+    {
+        WeakReferenceMessenger.Default.Send<StartAccountMessage>(new(this, true));
+    }
+
+    [RelayCommand]
+    private void ToggleSelection()
+    {
+        UseCheck = !UseCheck;
+    }
+
+    [RelayCommand]
+    private void AddToGroup()
+    {
+        WeakReferenceMessenger.Default.Send<AddAccountToGroupMessage>(new(this));
+    }
 }

--- a/Skua.Core/ViewModels/Manager/AccountManagerViewModel.cs
+++ b/Skua.Core/ViewModels/Manager/AccountManagerViewModel.cs
@@ -9,17 +9,25 @@ using Skua.Core.Messaging;
 using Skua.Core.Models;
 using Skua.Core.Models.Servers;
 using Skua.Core.Utils;
+using Skua.Core.ViewModels.Manager;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Skua.Core.ViewModels.Manager;
 
 public sealed partial class AccountManagerViewModel : BotControlViewModelBase
 {
+    // Constructor and Dependencies
     public AccountManagerViewModel(ISettingsService settingsService, IDialogService dialogService, IFileDialogService fileService)
         : base("Accounts")
     {
         Messenger.Register<AccountManagerViewModel, RemoveAccountMessage>(this, (r, m) => r._RemoveAccount(m.Account));
         Messenger.Register<AccountManagerViewModel, AccountSelectedMessage>(this, AccountSelected);
+        Messenger.Register<AccountManagerViewModel, StartAccountMessage>(this, (r, m) => r._StartAccount(m.Account, m.WithScript));
+        Messenger.Register<AccountManagerViewModel, RemoveGroupMessage>(this, (r, m) => r._RemoveGroup(m.Group));
+        Messenger.Register<AccountManagerViewModel, RenameGroupMessage>(this, (r, m) => r._RenameGroup(m.Group));
+        Messenger.Register<AccountManagerViewModel, RemoveAccountFromGroupMessage>(this, (r, m) => r._RemoveAccountFromGroup(m.Group, m.Account));
         StrongReferenceMessenger.Default.Register<AccountManagerViewModel, LoadScriptMessage, int>(this,
             (int)MessageChannels.ScriptStatus, (r, m) => r.HandleLoadScript(m));
         _settingsService = settingsService;
@@ -29,26 +37,22 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
         Task.Run(async () => await _GetServers());
         Accounts = new();
         _GetSavedAccounts();
+        _GetSavedGroups();
+        RefreshTagFilters();
         _syncThemes = _settingsService.Get("syncTheme", false);
     }
 
     private readonly string _exePath = Path.Combine(AppContext.BaseDirectory, "Skua.exe");
-
     private readonly ISettingsService _settingsService;
     private readonly IDialogService _dialogService;
     private readonly IFileDialogService _fileService;
 
+    // Collections
     public RangedObservableCollection<AccountItemViewModel> Accounts { get; }
+    public RangedObservableCollection<AccountItemViewModel> FilteredAccounts { get; } = new();
+    public RangedObservableCollection<GroupItemViewModel> Groups { get; } = new();
 
-    [ObservableProperty]
-    private string _scriptPath = string.Empty;
-
-    [ObservableProperty]
-    private bool _startWithScript;
-
-    [ObservableProperty]
-    private int _columns = 1;
-
+    // Account Properties
     [ObservableProperty]
     private int _selectedAccountQuant;
 
@@ -57,6 +61,58 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
 
     [ObservableProperty]
     private string _displayNameInput;
+
+    public string PasswordInput { private get; set; }
+
+    // UI State Properties
+    [ObservableProperty]
+    private bool _showTags;
+
+    [ObservableProperty]
+    private bool _showGridView;
+
+    [ObservableProperty]
+    private int _columns = 3;
+
+    [ObservableProperty]
+    private bool _useNameAsDisplay;
+
+    // Tag Filtering Properties
+    [ObservableProperty]
+    private bool _isFilterPopupOpen;
+
+    private string _tagFilter = string.Empty;
+    public string TagFilter
+    {
+        get => _tagFilter;
+        set
+        {
+            if (SetProperty(ref _tagFilter, value))
+                ApplyTagFilter();
+        }
+    }
+
+    private string _tagSearchText = string.Empty;
+    public string TagSearchText
+    {
+        get => _tagSearchText;
+        set
+        {
+            if (SetProperty(ref _tagSearchText, value))
+                _UpdateFilteredTags();
+        }
+    }
+
+    public ObservableCollection<TagFilterItem> AllTags { get; } = new();
+    public ObservableCollection<TagFilterItem> FilteredTags { get; } = new();
+    private HashSet<string> _selectedTagFilters = new();
+
+    // Script and Server Properties
+    [ObservableProperty]
+    private string _scriptPath = string.Empty;
+
+    [ObservableProperty]
+    private bool _startWithScript;
 
     [ObservableProperty]
     private Server _selectedServer;
@@ -67,9 +123,6 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
             _settingsService.Set("LastServer", value.Name);
     }
 
-    [ObservableProperty]
-    private bool _useNameAsDisplay;
-
     private List<Server> _cachedServers = new();
 
     [ObservableProperty]
@@ -77,17 +130,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
 
     private bool _syncThemes;
 
-    public string PasswordInput { private get; set; }
-
-    [RelayCommand]
-    public void ChangeScriptPath()
-    {
-        string? folderPath = _fileService.OpenFile(ClientFileSources.SkuaScriptsDIR, "Skua Scripts (*.cs)|*.cs");
-
-        if (!string.IsNullOrEmpty(folderPath))
-            ScriptPath = folderPath;
-    }
-
+    // Account Management
     [RelayCommand]
     public void AddAccount()
     {
@@ -97,21 +140,28 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
             return;
         }
 
-        if (string.IsNullOrEmpty(DisplayNameInput) && !UseNameAsDisplay)
+        // Check if account with this username already exists
+        AccountItemViewModel? existingAccount = Accounts.FirstOrDefault(a => a.Username.Equals(UsernameInput, StringComparison.OrdinalIgnoreCase));
+
+        if (existingAccount != null)
         {
-            _dialogService.ShowMessageBox("Display name must not be empty when \"Username as Display\" is not checked", "Missing Input");
-            return;
+            // Update existing account
+            existingAccount.Password = PasswordInput;
+            existingAccount.DisplayName = string.IsNullOrEmpty(DisplayNameInput) ? UsernameInput : DisplayNameInput;
+        }
+        else
+        {
+            // Create new account
+            AccountItemViewModel newAccount = new()
+            {
+                Username = UsernameInput,
+                Password = PasswordInput,
+                DisplayName = string.IsNullOrEmpty(DisplayNameInput) ? UsernameInput : DisplayNameInput
+            };
+            Accounts.Add(newAccount);
         }
 
-        AccountItemViewModel newAccount = new()
-        {
-            Username = UsernameInput,
-            Password = PasswordInput,
-            DisplayName = string.IsNullOrEmpty(DisplayNameInput) && !UseNameAsDisplay
-                ? $"{Accounts.Count + 1}"
-                : UseNameAsDisplay ? UsernameInput : DisplayNameInput
-        };
-        Accounts.Add(newAccount);
+        ApplyTagFilter();
 
         UsernameInput = string.Empty;
         DisplayNameInput = string.Empty;
@@ -165,43 +215,57 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
     }
 
     [RelayCommand]
-    public void OpenGetScripts()
+    private void DeselectAll()
     {
-        IServiceProvider? services = Ioc.Default.GetService<IServiceProvider>();
-        if (services != null)
+        foreach (AccountItemViewModel account in Accounts)
         {
-            ManagedWindows.RegisterForManager(services);
+            account.UseCheck = false;
         }
-
-        IWindowService? windowService = Ioc.Default.GetService<IWindowService>();
-        windowService?.ShowManagedWindow("Script Repo");
     }
 
     private void _RemoveAccount(AccountItemViewModel account)
     {
-        Accounts.Remove(account);
-        SelectedAccountQuant--;
+        if (account.UseCheck)
+            SelectedAccountQuant--;
 
-        _SaveAccounts();
-    }
-
-    private void _SaveAccounts()
-    {
-        Dictionary<string, AccountData> accs = new(StringComparer.OrdinalIgnoreCase);
-        foreach (AccountItemViewModel account in Accounts)
+        // Remove account from all groups
+        foreach (GroupItemViewModel group in Groups.ToList())
         {
-            accs[account.Username] = new AccountData
+            if (group.Accounts.Contains(account))
             {
-                DisplayName = account.DisplayName,
-                Password = account.Password,
-                Tags = account.Tags.ToList()
-            };
+                group.Accounts.Remove(account);
+            }
         }
 
-        _settingsService.Set("ManagedAccounts", accs);
+        Accounts.Remove(account);
+        FilteredAccounts.Remove(account);
+
+        _SaveAccounts();
+        _SaveGroups();
     }
 
-    private void _LaunchAcc(string username, string password, string displayName = null)
+    private void AccountSelected(AccountManagerViewModel recipient, AccountSelectedMessage message)
+    {
+        if (message.Add)
+            recipient.SelectedAccountQuant++;
+        else
+            recipient.SelectedAccountQuant--;
+    }
+
+    private void _StartAccount(AccountItemViewModel account, bool withScript)
+    {
+        _syncThemes = _settingsService.Get("syncTheme", false);
+
+        if (withScript && string.IsNullOrEmpty(ScriptPath))
+        {
+            _dialogService.ShowMessageBox("No script selected. Please select a script first.", "No Script");
+            return;
+        }
+
+        _LaunchAcc(account.Username, account.Password, account.DisplayName, withScript);
+    }
+
+    private void _LaunchAcc(string username, string password, string displayName = null, bool? withScript = null)
     {
         try
         {
@@ -225,7 +289,8 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
                 psi.ArgumentList.Add(_settingsService.Get("CurrentTheme", "no-theme"));
             }
 
-            if (StartWithScript)
+            bool shouldUseScript = withScript ?? StartWithScript;
+            if (shouldUseScript)
             {
                 psi.ArgumentList.Add("--run-script");
                 psi.ArgumentList.Add(ScriptPath);
@@ -234,7 +299,6 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
             Process? process = Process.Start(psi);
             if (process != null)
             {
-                // Send message to LauncherViewModel to add this process with the account display name
                 string accountName = !string.IsNullOrEmpty(displayName) ? displayName : username;
                 StrongReferenceMessenger.Default.Send(new AddProcessMessage(process, accountName));
             }
@@ -245,9 +309,200 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
         }
     }
 
+    // Group Management
+    public void AddGroup(string groupName)
+    {
+        if (string.IsNullOrWhiteSpace(groupName))
+            return;
+
+        if (Groups.Any(g => g.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase)))
+        {
+            _dialogService.ShowMessageBox($"A group named '{groupName}' already exists.", "Duplicate Group");
+            return;
+        }
+
+        GroupItemViewModel newGroup = new GroupItemViewModel(groupName);
+        Groups.Add(newGroup);
+        _SaveGroups();
+    }
+
+    public void AddAccountToGroup(AccountItemViewModel account, GroupItemViewModel group)
+    {
+        if (!group.Accounts.Contains(account))
+        {
+            group.Accounts.Add(account);
+            _SaveGroups();
+        }
+    }
+
+    private void _RemoveGroup(GroupItemViewModel group)
+    {
+        if (Groups.Contains(group))
+        {
+            Groups.Remove(group);
+            _SaveGroups();
+        }
+    }
+
+    private void _RenameGroup(GroupItemViewModel group)
+    {
+        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+            "Rename Group", "Enter new group name", "Group Name", numericInputOnly: false)
+        {
+            DialogTextInput = group.Name
+        };
+
+        bool? result = _dialogService.ShowDialog(inputDialogViewModel, "Rename Group");
+
+        if (result == true && !string.IsNullOrWhiteSpace(inputDialogViewModel.DialogTextInput))
+        {
+            string newName = inputDialogViewModel.DialogTextInput.Trim();
+
+            if (newName.Equals(group.Name, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            if (Groups.Any(g => g.Name.Equals(newName, StringComparison.OrdinalIgnoreCase)))
+            {
+                _dialogService.ShowMessageBox($"A group named '{newName}' already exists.", "Duplicate Group");
+                return;
+            }
+
+            group.Name = newName;
+
+            _SaveGroups();
+        }
+    }
+
+    private void _RemoveAccountFromGroup(GroupItemViewModel group, AccountItemViewModel account)
+    {
+        if (group.Accounts.Contains(account))
+        {
+            group.Accounts.Remove(account);
+            _SaveGroups();
+        }
+    }
+
+    // Tag Filtering
+    public void RefreshTagFilters()
+    {
+        // Remember which tags were selected before refresh
+        HashSet<string> previouslySelected = new HashSet<string>(_selectedTagFilters, StringComparer.OrdinalIgnoreCase);
+
+        AllTags.Clear();
+        Dictionary<string, int> tagCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (AccountItemViewModel account in Accounts)
+        {
+            foreach (string tag in account.Tags)
+            {
+                if (tagCounts.ContainsKey(tag))
+                    tagCounts[tag]++;
+                else
+                    tagCounts[tag] = 1;
+            }
+        }
+
+        foreach (KeyValuePair<string, int> kvp in tagCounts.OrderBy(x => x.Key))
+        {
+            TagFilterItem tagItem = new TagFilterItem(kvp.Key, kvp.Value);
+
+            // Restore selection state if this tag was previously selected
+            if (previouslySelected.Contains(kvp.Key))
+            {
+                tagItem.IsSelected = true;
+            }
+
+            tagItem.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(TagFilterItem.IsSelected))
+                {
+                    _OnTagFilterSelectionChanged();
+                }
+            };
+            AllTags.Add(tagItem);
+        }
+
+        // Remove any selected tags that no longer exist
+        _selectedTagFilters.RemoveWhere(tag => !tagCounts.ContainsKey(tag));
+
+        _UpdateFilteredTags();
+    }
+
+    [RelayCommand]
+    private void ClearTagFilters()
+    {
+        foreach (TagFilterItem tag in AllTags)
+        {
+            tag.IsSelected = false;
+        }
+        TagSearchText = string.Empty;
+    }
+
+    public void ApplyTagFilter()
+    {
+        FilteredAccounts.Clear();
+
+        if (_selectedTagFilters.Count == 0)
+        {
+            FilteredAccounts.AddRange(Accounts);
+            return;
+        }
+
+        // Filter uses OR logic: shows accounts that have ANY of the selected tags
+        IEnumerable<AccountItemViewModel> filtered = Accounts.Where(a =>
+            a.Tags.Any(t => _selectedTagFilters.Contains(t))
+        );
+
+        FilteredAccounts.AddRange(filtered);
+    }
+
+    private void _UpdateFilteredTags()
+    {
+        FilteredTags.Clear();
+
+        IEnumerable<TagFilterItem> filtered = string.IsNullOrWhiteSpace(TagSearchText)
+            ? AllTags
+            : AllTags.Where(t => t.Name.Contains(TagSearchText, StringComparison.OrdinalIgnoreCase));
+
+        foreach (TagFilterItem tag in filtered)
+        {
+            FilteredTags.Add(tag);
+        }
+    }
+
+    private void _OnTagFilterSelectionChanged()
+    {
+        _selectedTagFilters.Clear();
+        foreach (TagFilterItem tag in AllTags.Where(t => t.IsSelected))
+        {
+            _selectedTagFilters.Add(tag.Name);
+        }
+        ApplyTagFilter();
+    }
+
+    // Persistence
+    public void SaveAccounts() => _SaveAccounts();
+
+    private void _SaveAccounts()
+    {
+        Dictionary<string, AccountData> accs = new(StringComparer.OrdinalIgnoreCase);
+        foreach (AccountItemViewModel account in Accounts)
+        {
+            accs[account.Username] = new AccountData
+            {
+                DisplayName = account.DisplayName,
+                Password = account.Password,
+                Tags = account.Tags.ToList()
+            };
+        }
+
+        _settingsService.Set("ManagedAccounts", accs);
+    }
+
     private void _GetSavedAccounts()
     {
         Accounts.Clear();
+        FilteredAccounts.Clear();
         Dictionary<string, AccountData>? accs = _settingsService.Get<Dictionary<string, AccountData>>("ManagedAccounts");
         if (accs is null)
             return;
@@ -263,6 +518,71 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
             foreach (string tag in kvp.Value.Tags)
                 accountVm.Tags.Add(tag);
             Accounts.Add(accountVm);
+        }
+
+        ApplyTagFilter();
+    }
+
+    private void _SaveGroups()
+    {
+        List<GroupData> groupsData = Groups.Select(g => new GroupData
+        {
+            Name = g.Name,
+            Accounts = g.Accounts.Select(a => a.Username).ToList()
+        }).ToList();
+
+        _settingsService.Set("AccountGroups", groupsData);
+        _SaveAccounts();
+    }
+
+    private void _GetSavedGroups()
+    {
+        try
+        {
+            List<GroupData>? groupsData = _settingsService.Get<List<GroupData>>("AccountGroups");
+
+            if (groupsData == null || groupsData.Count == 0)
+            {
+                Groups.Clear();
+                return;
+            }
+
+            List<GroupItemViewModel> loadedGroups = new List<GroupItemViewModel>();
+
+            foreach (GroupData groupData in groupsData)
+            {
+                try
+                {
+                    if (string.IsNullOrEmpty(groupData.Name))
+                        continue;
+
+                    GroupItemViewModel group = new GroupItemViewModel(groupData.Name);
+
+                    foreach (string username in groupData.Accounts)
+                    {
+                        if (!string.IsNullOrEmpty(username))
+                        {
+                            AccountItemViewModel? account = Accounts.FirstOrDefault(a => a.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+                            if (account != null && !group.Accounts.Contains(account))
+                            {
+                                group.Accounts.Add(account);
+                            }
+                        }
+                    }
+
+                    loadedGroups.Add(group);
+                }
+                catch
+                {
+                    continue;
+                }
+            }
+
+            Groups.ReplaceRange(loadedGroups);
+        }
+        catch
+        {
+            Groups.Clear();
         }
     }
 
@@ -288,16 +608,30 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
         }
         catch
         {
-            // Silently fail - UI will show no servers
         }
     }
 
-    private void AccountSelected(AccountManagerViewModel recipient, AccountSelectedMessage message)
+    // Script Commands
+    [RelayCommand]
+    public void ChangeScriptPath()
     {
-        if (message.Add)
-            recipient.SelectedAccountQuant++;
-        else
-            recipient.SelectedAccountQuant--;
+        string? folderPath = _fileService.OpenFile(ClientFileSources.SkuaScriptsDIR, "Skua Scripts (*.cs)|*.cs");
+
+        if (!string.IsNullOrEmpty(folderPath))
+            ScriptPath = folderPath;
+    }
+
+    [RelayCommand]
+    public void OpenGetScripts()
+    {
+        IServiceProvider? services = Ioc.Default.GetService<IServiceProvider>();
+        if (services != null)
+        {
+            ManagedWindows.RegisterForManager(services);
+        }
+
+        IWindowService? windowService = Ioc.Default.GetService<IWindowService>();
+        windowService?.ShowManagedWindow("Script Repo");
     }
 
     private void HandleLoadScript(LoadScriptMessage message)
@@ -305,10 +639,8 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
         if (string.IsNullOrEmpty(message.Path))
             return;
 
-        // Set the script path to the loaded script
         ScriptPath = message.Path;
 
-        // Optionally show a confirmation message
         _dialogService.ShowMessageBox($"Script loaded: {Path.GetFileName(message.Path)}", "Script Loaded");
     }
 }

--- a/Skua.Core/ViewModels/Manager/AccountManagerViewModel.cs
+++ b/Skua.Core/ViewModels/Manager/AccountManagerViewModel.cs
@@ -9,10 +9,8 @@ using Skua.Core.Messaging;
 using Skua.Core.Models;
 using Skua.Core.Models.Servers;
 using Skua.Core.Utils;
-using Skua.Core.ViewModels.Manager;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Skua.Core.ViewModels.Manager;
 
@@ -136,7 +134,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
     {
         if (string.IsNullOrEmpty(UsernameInput) || string.IsNullOrEmpty(PasswordInput))
         {
-            _dialogService.ShowMessageBox("Username and/or password must not be empty", "Missing Input");
+            _dialogService.ShowMessageBox("Username or password must not be empty", "Missing Input");
             return;
         }
 
@@ -321,7 +319,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
             return;
         }
 
-        GroupItemViewModel newGroup = new GroupItemViewModel(groupName);
+        GroupItemViewModel newGroup = new(groupName);
         Groups.Add(newGroup);
         _SaveGroups();
     }
@@ -346,7 +344,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
 
     private void _RenameGroup(GroupItemViewModel group)
     {
-        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+        InputDialogViewModel inputDialogViewModel = new(
             "Rename Group", "Enter new group name", "Group Name", numericInputOnly: false)
         {
             DialogTextInput = group.Name
@@ -386,10 +384,10 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
     public void RefreshTagFilters()
     {
         // Remember which tags were selected before refresh
-        HashSet<string> previouslySelected = new HashSet<string>(_selectedTagFilters, StringComparer.OrdinalIgnoreCase);
+        HashSet<string> previouslySelected = new(_selectedTagFilters, StringComparer.OrdinalIgnoreCase);
 
         AllTags.Clear();
-        Dictionary<string, int> tagCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, int> tagCounts = new(StringComparer.OrdinalIgnoreCase);
 
         foreach (AccountItemViewModel account in Accounts)
         {
@@ -404,7 +402,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
 
         foreach (KeyValuePair<string, int> kvp in tagCounts.OrderBy(x => x.Key))
         {
-            TagFilterItem tagItem = new TagFilterItem(kvp.Key, kvp.Value);
+            TagFilterItem tagItem = new(kvp.Key, kvp.Value);
 
             // Restore selection state if this tag was previously selected
             if (previouslySelected.Contains(kvp.Key))
@@ -547,7 +545,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
                 return;
             }
 
-            List<GroupItemViewModel> loadedGroups = new List<GroupItemViewModel>();
+            List<GroupItemViewModel> loadedGroups = new();
 
             foreach (GroupData groupData in groupsData)
             {
@@ -556,7 +554,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
                     if (string.IsNullOrEmpty(groupData.Name))
                         continue;
 
-                    GroupItemViewModel group = new GroupItemViewModel(groupData.Name);
+                    GroupItemViewModel group = new(groupData.Name);
 
                     foreach (string username in groupData.Accounts)
                     {
@@ -622,7 +620,7 @@ public sealed partial class AccountManagerViewModel : BotControlViewModelBase
 
         List<Task> pingTasks = servers.Select(server => Task.Run(async () =>
         {
-            using (System.Net.NetworkInformation.Ping pinger = new System.Net.NetworkInformation.Ping())
+            using (System.Net.NetworkInformation.Ping pinger = new())
             {
                 try
                 {

--- a/Skua.Core/ViewModels/Manager/GroupItemViewModel.cs
+++ b/Skua.Core/ViewModels/Manager/GroupItemViewModel.cs
@@ -1,0 +1,48 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Skua.Core.Messaging;
+using System.Collections.ObjectModel;
+
+namespace Skua.Core.ViewModels.Manager;
+
+public partial class GroupItemViewModel : ObservableObject
+{
+    public GroupItemViewModel(string name)
+    {
+        Name = name;
+        Accounts = new ObservableCollection<AccountItemViewModel>();
+    }
+
+    [ObservableProperty]
+    private string _name;
+
+    [ObservableProperty]
+    private bool _isExpanded;
+
+    public ObservableCollection<AccountItemViewModel> Accounts { get; }
+
+    [RelayCommand]
+    private void Remove()
+    {
+        WeakReferenceMessenger.Default.Send<RemoveGroupMessage>(new(this));
+    }
+
+    [RelayCommand]
+    private void Start()
+    {
+        WeakReferenceMessenger.Default.Send<StartGroupMessage>(new(this, false));
+    }
+
+    [RelayCommand]
+    private void StartWithScript()
+    {
+        WeakReferenceMessenger.Default.Send<StartGroupMessage>(new(this, true));
+    }
+
+    [RelayCommand]
+    private void Rename()
+    {
+        WeakReferenceMessenger.Default.Send<RenameGroupMessage>(new(this));
+    }
+}

--- a/Skua.Core/ViewModels/Manager/SelectGroupDialogViewModel.cs
+++ b/Skua.Core/ViewModels/Manager/SelectGroupDialogViewModel.cs
@@ -1,0 +1,32 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+
+namespace Skua.Core.ViewModels.Manager;
+
+public partial class SelectGroupDialogViewModel : ObservableObject
+{
+    public SelectGroupDialogViewModel(IEnumerable<GroupItemViewModel> groups)
+    {
+        Groups = new ObservableCollection<GroupItemViewModel>(groups);
+    }
+
+    public ObservableCollection<GroupItemViewModel> Groups { get; }
+
+    [ObservableProperty]
+    private GroupItemViewModel? _selectedGroup;
+
+    public bool DialogResult { get; private set; }
+
+    [RelayCommand]
+    private void Confirm()
+    {
+        DialogResult = SelectedGroup != null;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        DialogResult = false;
+    }
+}

--- a/Skua.Core/ViewModels/Manager/TagFilterItem.cs
+++ b/Skua.Core/ViewModels/Manager/TagFilterItem.cs
@@ -1,0 +1,21 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Skua.Core.ViewModels.Manager;
+
+public partial class TagFilterItem : ObservableObject
+{
+    [ObservableProperty]
+    private string _name;
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    [ObservableProperty]
+    private int _count;
+
+    public TagFilterItem(string name, int count)
+    {
+        _name = name;
+        _count = count;
+    }
+}

--- a/Skua.WPF/Converters/ColumnWidthConverter.cs
+++ b/Skua.WPF/Converters/ColumnWidthConverter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Skua.WPF.Converters;
+
+public class ColumnWidthConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        // Check for unset or null values
+        if (values == null || values.Length < 2 ||
+            values[0] == System.Windows.DependencyProperty.UnsetValue ||
+            values[1] == System.Windows.DependencyProperty.UnsetValue)
+        {
+            return 200.0; // Default fallback width
+        }
+
+        if (values[0] is double containerWidth && values[1] is int columns)
+        {
+            if (columns <= 0) columns = 1;
+            if (containerWidth <= 0) return 200.0;
+
+            // Calculate width: (containerWidth - scrollbar - padding - margins) / columns
+            // Account for: 6px right margin per item, 4px padding on each side of ScrollViewer
+            double totalMargin = 6 * columns + 8; // 8 for ScrollViewer padding (4 * 2)
+            double availableWidth = containerWidth - totalMargin - 20; // 20 for potential scrollbar
+            double itemWidth = availableWidth / columns;
+
+            return Math.Max(100, itemWidth); // Minimum width of 100
+        }
+
+        return 200.0; // Default fallback width
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Skua.WPF/Converters/ColumnWidthConverter.cs
+++ b/Skua.WPF/Converters/ColumnWidthConverter.cs
@@ -6,6 +6,15 @@ namespace Skua.WPF.Converters;
 
 public class ColumnWidthConverter : IMultiValueConverter
 {
+    // Layout constants (matching AccountManager.xaml)
+    private const double DefaultItemWidth = 200.0;
+    private const double MinimumItemWidth = 100.0;
+    private const double ScrollViewerPaddingLeft = 4.0;
+    private const double ScrollViewerPaddingRight = 4.0;
+    private const double CardMarginRight = 4.0;
+    private const double CardMarginBottom = 4.0;
+    private const double ScrollbarWidth = 9.0;
+
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         // Check for unset or null values
@@ -13,24 +22,28 @@ public class ColumnWidthConverter : IMultiValueConverter
             values[0] == System.Windows.DependencyProperty.UnsetValue ||
             values[1] == System.Windows.DependencyProperty.UnsetValue)
         {
-            return 200.0; // Default fallback width
+            return DefaultItemWidth;
         }
 
         if (values[0] is double containerWidth && values[1] is int columns)
         {
             if (columns <= 0) columns = 1;
-            if (containerWidth <= 0) return 200.0;
+            if (containerWidth <= 0) return DefaultItemWidth;
 
-            // Calculate width: (containerWidth - scrollbar - padding - margins) / columns
-            // Account for: 6px right margin per item, 4px padding on each side of ScrollViewer
-            double totalMargin = 6 * columns + 8; // 8 for ScrollViewer padding (4 * 2)
-            double availableWidth = containerWidth - totalMargin - 20; // 20 for potential scrollbar
+            // Calculate item width based on available space
+            // Formula: (containerWidth - scrollViewerPadding - cardMargins - scrollbarSpace) / columns
+
+            double scrollViewerPadding = ScrollViewerPaddingLeft + ScrollViewerPaddingRight;
+            double totalCardMargins = CardMarginRight * columns; // Right margin for each card
+            double reservedSpace = scrollViewerPadding + totalCardMargins + ScrollbarWidth;
+
+            double availableWidth = containerWidth - reservedSpace;
             double itemWidth = availableWidth / columns;
 
-            return Math.Max(100, itemWidth); // Minimum width of 100
+            return Math.Max(MinimumItemWidth, itemWidth);
         }
 
-        return 200.0; // Default fallback width
+        return DefaultItemWidth;
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/Skua.WPF/Converters/EqualToConverter.cs
+++ b/Skua.WPF/Converters/EqualToConverter.cs
@@ -10,10 +10,10 @@ public class EqualToConverter : IValueConverter
     {
         if (value is null && parameter is null)
             return true;
-            
+
         if (value is null || parameter is null)
             return false;
-            
+
         return value.Equals(parameter) || value.ToString().Equals(parameter.ToString());
     }
 

--- a/Skua.WPF/UserControls/AccountItemUserControl.xaml
+++ b/Skua.WPF/UserControls/AccountItemUserControl.xaml
@@ -41,9 +41,6 @@
 
         <!-- List View Style (simple version) -->
         <Border
-            BorderBrush="{DynamicResource MaterialDesignDivider}"
-            BorderThickness="1"
-            Background="Transparent"
             Margin="0,0,0,0"
             Cursor="Hand"
             MouseLeftButtonUp="Border_MouseLeftButtonUp"
@@ -51,14 +48,13 @@
             <Border.Style>
                 <Style TargetType="Border">
                     <Setter Property="Padding" Value="8,6" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderBrush" Value="Transparent" />
+                    <Setter Property="BorderThickness" Value="1" />
                     <Style.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource MaterialDesignSelection}" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignDivider}" />
                         </Trigger>
-                        <DataTrigger Binding="{Binding UseCheck}" Value="True">
-                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
-                            <Setter Property="BorderThickness" Value="2" />
-                        </DataTrigger>
                     </Style.Triggers>
                 </Style>
             </Border.Style>
@@ -135,19 +131,7 @@
                     VerticalAlignment="Center"
                     Command="{Binding RemoveCommand}"
                     ToolTip="Remove Account"
-                    Background="Transparent"
-                    BorderThickness="0">
-                    <Button.Style>
-                        <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButton}">
-                            <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
-                            <Setter Property="Opacity" Value="0" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Border}, Path=IsMouseOver}" Value="True">
-                                    <Setter Property="Opacity" Value="1" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Button.Style>
+                    Style="{StaticResource MaterialDesignIconButton}">
                     <materialDesign:PackIcon
                         Kind="DeleteOutline"
                         Width="16"

--- a/Skua.WPF/UserControls/AccountItemUserControl.xaml
+++ b/Skua.WPF/UserControls/AccountItemUserControl.xaml
@@ -13,83 +13,147 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
     <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition />
-            <ColumnDefinition Width="auto" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="auto" />
-        </Grid.RowDefinitions>
-        <CheckBox
-            Grid.Row="0"
-            Grid.Column="0"
-            Margin="0,0,6,0"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            materialDesign:CheckBoxAssist.CheckBoxSize="24"
-            IsChecked="{Binding UseCheck}" />
-        <Expander
-            Grid.Row="0"
-            Grid.Column="1"
-            Padding="0"
-            Margin="0"
-            VerticalAlignment="Center"
+        <Grid.Resources>
+            <ContextMenu x:Key="AccountContextMenu">
+                <MenuItem Header="Edit Tags" Command="{Binding AddTagsCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="TagEdit" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Add to Group" Command="{Binding AddToGroupCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="AccountMultiplePlus" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <Separator />
+                <MenuItem Header="Start" Command="{Binding StartCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="PlayCircleOutline" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Start With Script" Command="{Binding StartWithScriptCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="ScriptTextPlayOutline" />
+                    </MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </Grid.Resources>
+
+        <!-- List View Style (simple version) -->
+        <Border
+            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            BorderThickness="1"
             Background="Transparent"
-            HorizontalAlignment="Stretch"
-            HorizontalContentAlignment="Stretch"
-            ExpandDirection="Down"
-            materialDesign:ExpanderAssist.HorizontalHeaderPadding="0"
-            Visibility="{Binding Tags.Count, Converter={StaticResource IntToVisibilityConverter}}">
-            <Expander.Header>
-                <DockPanel HorizontalAlignment="Stretch">
+            Margin="0,0,0,0"
+            Cursor="Hand"
+            MouseLeftButtonUp="Border_MouseLeftButtonUp"
+            ContextMenu="{StaticResource AccountContextMenu}">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Padding" Value="8,6" />
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource MaterialDesignSelection}" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding UseCheck}" Value="True">
+                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+                            <Setter Property="BorderThickness" Value="2" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <CheckBox
+                    Grid.Column="0"
+                    Margin="0,0,8,0"
+                    VerticalAlignment="Center"
+                    materialDesign:CheckBoxAssist.CheckBoxSize="20"
+                    IsChecked="{Binding UseCheck}"
+                    ToolTip="Select for batch operations" />
+
+                <Grid Grid.Column="1" VerticalAlignment="Center">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
                     <TextBlock
-                        DockPanel.Dock="Left"
-                        VerticalAlignment="Center"
+                        Grid.Row="0"
+                        FontSize="13"
+                        FontWeight="Medium"
                         Text="{Binding DisplayName, FallbackValue=Test1}" />
-                </DockPanel>
-            </Expander.Header>
-            <DockPanel Margin="24,0,0,0">
-                <TextBlock Text="Tags:"
-                    Foreground="#919191"
-                    Margin="0,0,5,0"
-                    VerticalAlignment="Top" />
-                <ItemsControl ItemsSource="{Binding Tags}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Border
-                                BorderBrush="{DynamicResource PrimaryHueMidBrush}"
-                                BorderThickness="1"
-                                CornerRadius="5"
-                                Padding="5,0,5,2"
-                                Margin="0,1,5,3">
-                                <TextBlock
-                                    Foreground="{DynamicResource PrimaryHueMidBrush}"
-                                    Text="{Binding}" />
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </DockPanel>
-        </Expander>
-        <TextBlock
-            Grid.Row="0"
-            Grid.Column="1"
-            VerticalAlignment="Center"
-            Text="{Binding DisplayName, FallbackValue=Test1}"
-            Visibility="{Binding Tags.Count, Converter={StaticResource IntToVisibilityConverter}, ConverterParameter=Inverse}" />
-        <Button
-            Grid.Row="0"
-            Grid.Column="2"
-            VerticalAlignment="Center"
-            Command="{Binding RemoveCommand}"
-            Content="{materialDesign:PackIcon Kind=Delete}"
-            Style="{StaticResource MaterialDesignFlatButton}" />
+
+                    <ItemsControl
+                        Grid.Row="1"
+                        ItemsSource="{Binding Tags}"
+                        Margin="0,3,0,0">
+                        <ItemsControl.Style>
+                            <Style TargetType="ItemsControl">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=views:AccountManagerView}, Path=DataContext.ShowTags}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ItemsControl.Style>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border
+                                    Background="{DynamicResource PrimaryHueMidBrush}"
+                                    CornerRadius="2"
+                                    Padding="5,1"
+                                    Margin="0,0,3,2"
+                                    Opacity="0.85">
+                                    <TextBlock
+                                        FontSize="10"
+                                        FontWeight="Medium"
+                                        Foreground="White"
+                                        Text="{Binding}" />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Grid>
+
+                <Button
+                    Grid.Column="2"
+                    Width="28"
+                    Height="28"
+                    Padding="0"
+                    VerticalAlignment="Center"
+                    Command="{Binding RemoveCommand}"
+                    ToolTip="Remove Account"
+                    Background="Transparent"
+                    BorderThickness="0">
+                    <Button.Style>
+                        <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButton}">
+                            <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                            <Setter Property="Opacity" Value="0" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Border}, Path=IsMouseOver}" Value="True">
+                                    <Setter Property="Opacity" Value="1" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                    <materialDesign:PackIcon
+                        Kind="DeleteOutline"
+                        Width="16"
+                        Height="16" />
+                </Button>
+            </Grid>
+        </Border>
     </Grid>
 </UserControl>

--- a/Skua.WPF/UserControls/AccountItemUserControl.xaml.cs
+++ b/Skua.WPF/UserControls/AccountItemUserControl.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System.Windows.Controls;
+using System.Windows.Input;
+using Skua.Core.ViewModels;
 
 namespace Skua.WPF.UserControls;
 
@@ -10,5 +12,17 @@ public partial class AccountItemUserControl : UserControl
     public AccountItemUserControl()
     {
         InitializeComponent();
+    }
+
+    private void Border_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        // Don't toggle if clicking on a button or checkbox
+        if (e.OriginalSource is System.Windows.Controls.Primitives.ButtonBase or CheckBox)
+            return;
+
+        if (DataContext is AccountItemViewModel vm)
+        {
+            vm.ToggleSelectionCommand.Execute(null);
+        }
     }
 }

--- a/Skua.WPF/UserControls/AccountItemUserControl.xaml.cs
+++ b/Skua.WPF/UserControls/AccountItemUserControl.xaml.cs
@@ -1,6 +1,6 @@
-﻿using System.Windows.Controls;
+﻿using Skua.Core.ViewModels;
+using System.Windows.Controls;
 using System.Windows.Input;
-using Skua.Core.ViewModels;
 
 namespace Skua.WPF.UserControls;
 

--- a/Skua.WPF/UserControls/Dialogs/SelectGroupDialog.xaml
+++ b/Skua.WPF/UserControls/Dialogs/SelectGroupDialog.xaml
@@ -1,0 +1,46 @@
+<UserControl
+    x:Class="Skua.WPF.UserControls.SelectGroupDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Skua.WPF.UserControls"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vms="clr-namespace:Skua.Core.ViewModels.Manager;assembly=Skua.Core"
+    d:DataContext="{d:DesignInstance vms:SelectGroupDialogViewModel}"
+    d:DesignHeight="150"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+    <StackPanel>
+        <TextBlock
+            Margin="6"
+            Style="{StaticResource MaterialDesignBody1TextBlock}"
+            Text="Select a group:" />
+        <ComboBox
+            Margin="6"
+            DisplayMemberPath="Name"
+            IsEditable="True"
+            IsTextSearchEnabled="True"
+            ItemsSource="{Binding Groups}"
+            SelectedItem="{Binding SelectedGroup}"
+            TextSearch.TextPath="Name"
+            materialDesign:HintAssist.Hint="Search groups..." />
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <Button
+                Grid.Column="0"
+                Margin="6"
+                Click="BtnConfirm_Click"
+                Content="Add"
+                IsDefault="True" />
+            <Button
+                Grid.Column="1"
+                Margin="6"
+                Content="Cancel"
+                IsCancel="True" />
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/Skua.WPF/UserControls/Dialogs/SelectGroupDialog.xaml.cs
+++ b/Skua.WPF/UserControls/Dialogs/SelectGroupDialog.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Skua.WPF.UserControls;
+
+/// <summary>
+/// Interaction logic for SelectGroupDialog.xaml
+/// </summary>
+public partial class SelectGroupDialog : UserControl
+{
+    public SelectGroupDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void BtnConfirm_Click(object sender, RoutedEventArgs e)
+    {
+        Window parent = Window.GetWindow(this);
+        parent.DialogResult = true;
+    }
+}

--- a/Skua.WPF/UserControls/GroupItemUserControl.xaml
+++ b/Skua.WPF/UserControls/GroupItemUserControl.xaml
@@ -23,6 +23,7 @@
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
                 <TextBlock
@@ -64,6 +65,23 @@
 
                 <Button
                     Grid.Column="3"
+                    Width="28"
+                    Height="28"
+                    Padding="0"
+                    Margin="0,0,4,0"
+                    Command="{Binding RenameCommand}"
+                    Style="{StaticResource MaterialDesignIconButton}"
+                    ToolTip="Rename Group"
+                    Foreground="{DynamicResource MaterialDesignBodyLight}"
+                    Opacity="0.7">
+                    <materialDesign:PackIcon
+                        Kind="PencilOutline"
+                        Width="16"
+                        Height="16" />
+                </Button>
+
+                <Button
+                    Grid.Column="4"
                     Width="28"
                     Height="28"
                     Padding="0"

--- a/Skua.WPF/UserControls/GroupItemUserControl.xaml
+++ b/Skua.WPF/UserControls/GroupItemUserControl.xaml
@@ -1,0 +1,150 @@
+<UserControl
+    x:Class="Skua.WPF.UserControls.GroupItemUserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Skua.WPF.UserControls"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vms="clr-namespace:Skua.Core.ViewModels.Manager;assembly=Skua.Core"
+    d:DataContext="{d:DesignInstance vms:GroupItemViewModel}"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
+    <Expander
+        Margin="8,0"
+        IsExpanded="{Binding IsExpanded}"
+        BorderBrush="{DynamicResource MaterialDesignDivider}"
+        BorderThickness="0,0,0,1">
+        <Expander.Header>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock
+                    Grid.Column="0"
+                    FontSize="13"
+                    FontWeight="Medium"
+                    VerticalAlignment="Center"
+                    Text="{Binding Name}" />
+
+                <Button
+                    Grid.Column="1"
+                    Width="28"
+                    Height="28"
+                    Padding="0"
+                    Margin="4,0"
+                    Command="{Binding StartCommand}"
+                    Style="{StaticResource MaterialDesignIconButton}"
+                    ToolTip="Start Group">
+                    <materialDesign:PackIcon
+                        Kind="PlayCircleOutline"
+                        Width="16"
+                        Height="16" />
+                </Button>
+
+                <Button
+                    Grid.Column="2"
+                    Width="28"
+                    Height="28"
+                    Padding="0"
+                    Margin="0,0,4,0"
+                    Command="{Binding StartWithScriptCommand}"
+                    Style="{StaticResource MaterialDesignIconButton}"
+                    ToolTip="Start Group With Script">
+                    <materialDesign:PackIcon
+                        Kind="ScriptTextPlayOutline"
+                        Width="16"
+                        Height="16" />
+                </Button>
+
+                <Button
+                    Grid.Column="3"
+                    Width="28"
+                    Height="28"
+                    Padding="0"
+                    Command="{Binding RemoveCommand}"
+                    Style="{StaticResource MaterialDesignIconButton}"
+                    ToolTip="Remove Group"
+                    Foreground="{DynamicResource MaterialDesignBodyLight}"
+                    Opacity="0.7">
+                    <materialDesign:PackIcon
+                        Kind="DeleteOutline"
+                        Width="16"
+                        Height="16" />
+                </Button>
+            </Grid>
+        </Expander.Header>
+
+        <ItemsControl ItemsSource="{Binding Accounts}" Margin="0,4">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border
+                        Margin="8,0,8,4"
+                        Padding="12,6"
+                        Background="{DynamicResource MaterialDesignCardBackground}"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}"
+                        BorderThickness="1"
+                        CornerRadius="2">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                <TextBlock
+                                    FontSize="12"
+                                    Text="{Binding DisplayName}" />
+                                <ItemsControl ItemsSource="{Binding Tags}" Margin="0,2,0,0">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <WrapPanel />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border
+                                                Background="{DynamicResource PrimaryHueMidBrush}"
+                                                CornerRadius="2"
+                                                Padding="4,1"
+                                                Margin="0,0,3,2"
+                                                Opacity="0.85">
+                                                <TextBlock
+                                                    FontSize="9"
+                                                    FontWeight="Medium"
+                                                    Foreground="White"
+                                                    Text="{Binding}" />
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+
+                            <Button
+                                Grid.Column="1"
+                                Width="24"
+                                Height="24"
+                                Padding="0"
+                                VerticalAlignment="Center"
+                                Click="RemoveAccountFromGroup_Click"
+                                Style="{StaticResource MaterialDesignIconButton}"
+                                ToolTip="Remove from Group"
+                                Foreground="{DynamicResource MaterialDesignBodyLight}"
+                                Opacity="0.6">
+                                <materialDesign:PackIcon
+                                    Kind="Close"
+                                    Width="14"
+                                    Height="14" />
+                            </Button>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Expander>
+</UserControl>

--- a/Skua.WPF/UserControls/GroupItemUserControl.xaml.cs
+++ b/Skua.WPF/UserControls/GroupItemUserControl.xaml.cs
@@ -1,9 +1,9 @@
-using System.Windows;
-using System.Windows.Controls;
 using CommunityToolkit.Mvvm.Messaging;
 using Skua.Core.Messaging;
 using Skua.Core.ViewModels;
 using Skua.Core.ViewModels.Manager;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace Skua.WPF.UserControls;
 

--- a/Skua.WPF/UserControls/GroupItemUserControl.xaml.cs
+++ b/Skua.WPF/UserControls/GroupItemUserControl.xaml.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+using System.Windows.Controls;
+using CommunityToolkit.Mvvm.Messaging;
+using Skua.Core.Messaging;
+using Skua.Core.ViewModels;
+using Skua.Core.ViewModels.Manager;
+
+namespace Skua.WPF.UserControls;
+
+/// <summary>
+/// Interaction logic for GroupItemUserControl.xaml
+/// </summary>
+public partial class GroupItemUserControl : UserControl
+{
+    public GroupItemUserControl()
+    {
+        InitializeComponent();
+    }
+
+    private void RemoveAccountFromGroup_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button &&
+            button.DataContext is AccountItemViewModel account &&
+            DataContext is GroupItemViewModel group)
+        {
+            WeakReferenceMessenger.Default.Send(new RemoveAccountFromGroupMessage(account, group));
+        }
+    }
+}

--- a/Skua.WPF/UserControls/GroupItemUserControl.xaml.cs
+++ b/Skua.WPF/UserControls/GroupItemUserControl.xaml.cs
@@ -23,7 +23,7 @@ public partial class GroupItemUserControl : UserControl
             button.DataContext is AccountItemViewModel account &&
             DataContext is GroupItemViewModel group)
         {
-            WeakReferenceMessenger.Default.Send(new RemoveAccountFromGroupMessage(account, group));
+            WeakReferenceMessenger.Default.Send(new RemoveAccountFromGroupMessage(group, account));
         }
     }
 }

--- a/Skua.WPF/UserControls/LauncherUserControl.xaml
+++ b/Skua.WPF/UserControls/LauncherUserControl.xaml
@@ -60,13 +60,32 @@
                                 </StackPanel>
                                 <Button
                                     Grid.Column="2"
+                                    Width="28"
+                                    Height="28"
+                                    Padding="0"
                                     Margin="10,0,0,0"
-                                    Style="{StaticResource MaterialDesignFlatButton}"
                                     ToolTip="Kill Process"
                                     Command="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=DataContext.StopProcessCommand}"
                                     CommandParameter="{Binding}"
-                                    Content="{materialDesign:PackIcon Kind=Close, Size=20}"
-                                    Foreground="{DynamicResource MaterialDesignValidationErrorBrush}" />
+                                    Background="{DynamicResource MaterialDesignPaper}"
+                                    BorderBrush="{DynamicResource MaterialDesignDivider}"
+                                    BorderThickness="1">
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButton}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Border}, Path=IsMouseOver}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                    <materialDesign:PackIcon
+                                        Kind="Close"
+                                        Width="16"
+                                        Height="16" />
+                                </Button>
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/Skua.WPF/Views/AboutView.xaml.cs
+++ b/Skua.WPF/Views/AboutView.xaml.cs
@@ -34,8 +34,7 @@ public partial class AboutView : UserControl
 
     private void SubscribeToAllHyperlinks(FlowDocument flowDocument)
     {
-        IEnumerable<Hyperlink> hyperlinks = GetVisuals(flowDocument).OfType<Hyperlink>();
-        foreach (Hyperlink link in hyperlinks)
+        foreach (Hyperlink link in GetVisuals(flowDocument).OfType<Hyperlink>())
             link.Command = ((AboutViewModel)DataContext).NavigateCommand;
     }
 

--- a/Skua.WPF/Views/AccountManager.xaml
+++ b/Skua.WPF/Views/AccountManager.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Skua.WPF.Views.AccountManagerView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -16,173 +16,651 @@
     mc:Ignorable="d">
 
     <Grid Margin="6">
+        <Grid.Resources>
+            <ContextMenu x:Key="AccountContextMenu">
+                <MenuItem Header="Start" Command="{Binding StartCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="PlayCircleOutline" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Start With Script" Command="{Binding StartWithScriptCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="ScriptTextPlayOutline" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <Separator />
+                <MenuItem Header="Edit Tags" Command="{Binding AddTagsCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="TagEdit" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Add to Group" Command="{Binding AddToGroupCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="AccountMultiplePlus" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <Separator />
+                <MenuItem Header="Remove" Command="{Binding RemoveCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="DeleteOutline" />
+                    </MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+
+            <ContextMenu x:Key="BulkAccountContextMenu">
+                <MenuItem Header="Start Selected" Command="{Binding StartAccountsCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="PlayCircleOutline" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Start Selected With Script" Command="{Binding StartAccountsCommand}" CommandParameter="true">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="ScriptTextPlayOutline" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Add Tags to Selected" Click="AddTagsToSelected_Click">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="TagPlus" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Add Selected to Group" Click="AddSelectedToGroup_Click">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="AccountMultiplePlus" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <Separator />
+                <MenuItem Header="Deselect All" Command="{Binding DeselectAllCommand}">
+                    <MenuItem.Icon>
+                        <materialDesign:PackIcon Kind="SelectOff" />
+                    </MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </Grid.Resources>
+
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="auto" />
-            <RowDefinition />
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Expander Grid.Row="0" Header="Add Account">
-            <Expander.Resources>
-                <Style BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}" TargetType="TextBox" />
-            </Expander.Resources>
-            <StackPanel>
-                <DockPanel>
-                    <CheckBox
-                        Margin="6,0"
-                        materialDesign:CheckBoxAssist.CheckBoxSize="25"
-                        Content="Username as Display"
-                        DockPanel.Dock="Right"
-                        IsChecked="{Binding UseNameAsDisplay}" />
-                    <TextBox
-                        Margin="6"
-                        materialDesign:HintAssist.Hint="Display Name"
-                        Text="{Binding DisplayNameInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                </DockPanel>
+
+        <!-- Add Account Form (Collapsible) -->
+        <Border
+            x:Name="AddAccountForm"
+            Grid.Row="0"
+            Visibility="Collapsed"
+            Background="{DynamicResource MaterialDesignCardBackground}"
+            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            BorderThickness="1"
+            CornerRadius="4"
+            Padding="8"
+            Margin="0,0,0,6">
+            <Grid>
+                <Grid.Resources>
+                    <Style BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}" TargetType="TextBox" />
+                </Grid.Resources>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
                 <TextBox
-                    Margin="6,0"
+                    Grid.Column="0"
+                    Margin="0,0,4,0"
                     materialDesign:HintAssist.Hint="Username"
                     Text="{Binding UsernameInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
                 <PasswordBox
                     x:Name="PswBox"
-                    Margin="6"
+                    Grid.Column="1"
+                    Margin="4,0"
                     materialDesign:HintAssist.Hint="Password"
                     PasswordChanged="PasswordBox_PasswordChanged"
                     Style="{StaticResource MaterialDesignFloatingHintPasswordBox}" />
+
+                <TextBox
+                    Grid.Column="2"
+                    Margin="4,0"
+                    materialDesign:HintAssist.Hint="Display Name (optional)"
+                    Text="{Binding DisplayNameInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
                 <Button
-                    Grid.Column="0"
-                    Margin="6,0,6,6"
-                    Command="{Binding AddAccountCommand}"
-                    Content="Add" />
-            </StackPanel>
-        </Expander>
-        <DockPanel
-            Grid.Row="1"
-            Margin="0,6"
-            LastChildFill="False">
-            <TextBox
-                Width="70"
-                Margin="3,6,6,6"
-                VerticalAlignment="Center"
-                materialDesign:HintAssist.Hint="Columns"
-                DockPanel.Dock="Right"
-                Text="{Binding Columns, UpdateSourceTrigger=PropertyChanged}">
-                <b:Interaction.Behaviors>
-                    <wpf:TextBoxOnlyNumbersBehavior />
-                </b:Interaction.Behaviors>
-            </TextBox>
-            <TextBlock
-                Margin="0,0,50,0"
-                VerticalAlignment="Center"
-                d:Text="000"
-                DockPanel.Dock="Right"
-                FontSize="18"
-                FontWeight="Bold"
-                Text="{Binding SelectedAccountQuant}" />
-            <TextBlock
-                Margin="0,0,10,0"
-                VerticalAlignment="Center"
-                DockPanel.Dock="Right"
-                FontSize="18"
-                Text="Selected:" />
-        </DockPanel>
-        <ScrollViewer
-            Grid.Row="2"
-            Margin="0,0,0,6"
-            materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True">
-            <ItemsControl
-                Margin="6,0,0,0"
-                d:ItemsSource="{d:SampleData ItemCount=15}"
-                ItemsSource="{Binding Accounts}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <usercontrols:AccountItemUserControl DataContext="{Binding}" />
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <StackPanel />
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-            </ItemsControl>
-        </ScrollViewer>
-        <Grid Grid.Row="3">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-            <ComboBox
-                Grid.Column="0"
-                Margin="0,0,5,0"
-                materialDesign:HintAssist.Hint="Login Server"
-                ItemsSource="{Binding ServerList, UpdateSourceTrigger=PropertyChanged}"
-                SelectedItem="{Binding SelectedServer}"
-                Style="{StaticResource MaterialDesignFloatingHintComboBox}"
-                ToolTip="Which server to login when launching accounts" />
-            <Button
-                Grid.Column="1"
-                Margin="5,0,5,0"
-                Command="{Binding StartAccountsCommand}"
-                Content="Start Selected"
-                ToolTip="Launch and login all the accounts with the checkbox marked" />
-            <Button
-                Grid.Column="2"
-                Margin="5,0,0,0"
-                Command="{Binding RemoveAccountsCommand}"
-                Content="Remove Selected"
-                ToolTip="Removes all accounts with the checkbox marked." />
-        </Grid>
-        <Button
-            Grid.Row="4"
-            Margin="0,5,0,0"
-            Command="{Binding StartAllAccountsCommand}"
-            Content="Start All"
-            ToolTip="Launchs all saved accounts" />
-        <Grid Grid.Row="5" Margin="0,6,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <DockPanel>
-                <Button
-                    Grid.Column="1"
-                    VerticalAlignment="Center"
-                    materialDesign:ButtonAssist.CornerRadius="0 2 2 0"
-                    Command="{Binding ChangeScriptPathCommand}"
-                    Content="{materialDesign:PackIcon Kind=Folder}"
-                    DockPanel.Dock="Right"
-                    ToolTip="Change the script path." />
-                <Border
-                    Grid.Column="0"
+                    Grid.Column="3"
+                    Width="32"
                     Height="32"
-                    BorderBrush="{DynamicResource PrimaryHueMidBrush}"
-                    BorderThickness="1,1,0,1"
-                    CornerRadius="2 0 0 2"
-                    ToolTip="Path to a script which will be loaded and started after launching an account.">
-                    <TextBlock
-                        Margin="16,0,0,0"
+                    Margin="4,0"
+                    Padding="0"
+                    Command="{Binding AddAccountCommand}"
+                    ToolTip="Add Account"
+                    Style="{StaticResource MaterialDesignIconButton}">
+                    <materialDesign:PackIcon Kind="Check" Width="20" Height="20" />
+                </Button>
+
+                <Button
+                    Grid.Column="4"
+                    Width="32"
+                    Height="32"
+                    Padding="0"
+                    Click="HideAddAccountButton_Click"
+                    ToolTip="Cancel"
+                    Style="{StaticResource MaterialDesignIconButton}">
+                    <materialDesign:PackIcon Kind="Close" Width="20" Height="20" />
+                </Button>
+            </Grid>
+        </Border>
+
+        <!-- Tab Control for Accounts/Groups -->
+        <TabControl Grid.Row="1" Style="{StaticResource MaterialDesignTabControl}">
+            <!-- Accounts Tab -->
+            <TabItem Header="Accounts">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <!-- Accounts Header with Controls -->
+                    <Grid Grid.Row="0" Margin="0,4,0,6">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            FontSize="14"
+                            Text="{Binding SelectedAccountQuant, StringFormat='Selected: {0}'}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SelectedAccountQuant, Converter={StaticResource IntToBooleanConverter}}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <ComboBox
+                            x:Name="ColumnsComboBox"
+                            Grid.Column="2"
+                            Width="45"
+                            Margin="0,0,8,0"
+                            VerticalAlignment="Center"
+                            SelectionChanged="ColumnsComboBox_SelectionChanged"
+                            ToolTip="Grid Columns">
+                            <ComboBox.Style>
+                                <Style TargetType="ComboBox" BasedOn="{StaticResource MaterialDesignComboBox}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ShowGridView}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ComboBox.Style>
+                            <ComboBoxItem>1</ComboBoxItem>
+                            <ComboBoxItem>2</ComboBoxItem>
+                            <ComboBoxItem>3</ComboBoxItem>
+                            <ComboBoxItem>4</ComboBoxItem>
+                            <ComboBoxItem>5</ComboBoxItem>
+                            <ComboBoxItem>6</ComboBoxItem>
+                        </ComboBox>
+
+                        <ToggleButton
+                            x:Name="FilterButton"
+                            Grid.Column="3"
+                            Width="32"
+                            Height="32"
+                            Margin="0,0,8,0"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding IsFilterPopupOpen}"
+                            ToolTip="Filter by tags"
+                            Style="{StaticResource MaterialDesignActionToggleButton}">
+                            <materialDesign:PackIcon Kind="FilterOutline" Width="18" Height="18" />
+                        </ToggleButton>
+                        <Popup
+                            PlacementTarget="{Binding ElementName=FilterButton}"
+                            IsOpen="{Binding IsFilterPopupOpen}"
+                            StaysOpen="False"
+                            AllowsTransparency="True"
+                            PopupAnimation="Fade">
+                            <Border
+                                Width="280"
+                                MaxHeight="400"
+                                Background="{DynamicResource MaterialDesignPaper}"
+                                BorderBrush="{DynamicResource MaterialDesignDivider}"
+                                BorderThickness="1"
+                                CornerRadius="4"
+                                Padding="12"
+                                Effect="{StaticResource MaterialDesignShadowDepth3}">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <TextBlock
+                                        Grid.Row="0"
+                                        Text="Filter by Tags"
+                                        FontWeight="Medium"
+                                        FontSize="14"
+                                        Margin="0,0,0,8" />
+
+                                    <TextBox
+                                        Grid.Row="1"
+                                        Margin="0,0,0,8"
+                                        materialDesign:HintAssist.Hint="Search tags..."
+                                        Text="{Binding TagSearchText, UpdateSourceTrigger=PropertyChanged}"
+                                        Style="{StaticResource MaterialDesignOutlinedTextBox}" />
+
+                                    <ScrollViewer
+                                        Grid.Row="2"
+                                        MaxHeight="300"
+                                        VerticalScrollBarVisibility="Auto"
+                                        materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True">
+                                        <ItemsControl ItemsSource="{Binding FilteredTags}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <CheckBox
+                                                        Margin="0,2"
+                                                        IsChecked="{Binding IsSelected}">
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <TextBlock Text="{Binding Name}" />
+                                                            <TextBlock
+                                                                Text="{Binding Count, StringFormat=' ({0})'}"
+                                                                Opacity="0.6"
+                                                                FontSize="11"
+                                                                Margin="4,0,0,0" />
+                                                        </StackPanel>
+                                                    </CheckBox>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </ScrollViewer>
+
+                                    <Button
+                                        Grid.Row="3"
+                                        Margin="0,8,0,0"
+                                        Command="{Binding ClearTagFiltersCommand}"
+                                        Content="Clear All"
+                                        Style="{StaticResource MaterialDesignOutlinedButton}" />
+                                </Grid>
+                            </Border>
+                        </Popup>
+
+                        <ToggleButton
+                            Grid.Column="4"
+                            Width="32"
+                            Height="32"
+                            Margin="0,0,8,0"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding ShowTags}"
+                            ToolTip="Toggle Tag Visibility"
+                            Style="{StaticResource MaterialDesignActionToggleButton}">
+                            <ToggleButton.Content>
+                                <materialDesign:PackIcon Kind="TagOutline" Width="16" Height="16" />
+                            </ToggleButton.Content>
+                            <materialDesign:ToggleButtonAssist.OnContent>
+                                <materialDesign:PackIcon Kind="Tag" Width="16" Height="16" />
+                            </materialDesign:ToggleButtonAssist.OnContent>
+                        </ToggleButton>
+
+                        <ToggleButton
+                            Grid.Column="5"
+                            Width="32"
+                            Height="32"
+                            Margin="0,0,8,0"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding ShowGridView}"
+                            ToolTip="Toggle Grid/List View"
+                            Style="{StaticResource MaterialDesignActionToggleButton}">
+                            <ToggleButton.Content>
+                                <materialDesign:PackIcon Kind="ViewList" Width="16" Height="16" />
+                            </ToggleButton.Content>
+                            <materialDesign:ToggleButtonAssist.OnContent>
+                                <materialDesign:PackIcon Kind="ViewGrid" Width="16" Height="16" />
+                            </materialDesign:ToggleButtonAssist.OnContent>
+                        </ToggleButton>
+
+                        <Button
+                            x:Name="ShowAddAccountButton"
+                            Grid.Column="6"
+                            Height="32"
+                            Padding="8,4"
+                            VerticalAlignment="Center"
+                            Click="ShowAddAccountButton_Click"
+                            ToolTip="Add Account"
+                            Style="{StaticResource MaterialDesignFlatButton}">
+                            <StackPanel Orientation="Horizontal">
+                                <materialDesign:PackIcon Kind="Plus" Width="14" Height="14" VerticalAlignment="Center" />
+                                <TextBlock Text="Add Account" FontSize="11" Margin="4,0,0,0" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                    </Grid>
+
+                    <!-- Accounts List/Grid View -->
+                    <ScrollViewer
+                        x:Name="AccountsScrollViewer"
+                        Grid.Row="1"
+                        Padding="4"
+                        materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True"
+                        ContextMenu="{StaticResource BulkAccountContextMenu}">
+                        <Grid>
+                            <!-- List View -->
+                            <ItemsControl
+                                ItemsSource="{Binding FilteredAccounts}">
+                                <ItemsControl.Style>
+                                    <Style TargetType="ItemsControl">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ShowGridView}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ItemsControl.Style>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <usercontrols:AccountItemUserControl DataContext="{Binding}" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!-- Grid View -->
+                            <ItemsControl
+                                ItemsSource="{Binding FilteredAccounts}">
+                                <ItemsControl.Style>
+                                    <Style TargetType="ItemsControl">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ShowGridView}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ItemsControl.Style>
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border
+                                            Margin="0,0,6,6"
+                                            Background="{DynamicResource MaterialDesignCardBackground}"
+                                            BorderBrush="{DynamicResource MaterialDesignDivider}"
+                                            BorderThickness="2"
+                                            CornerRadius="4"
+                                            Cursor="Hand"
+                                            ContextMenu="{StaticResource AccountContextMenu}">
+                                            <Border.InputBindings>
+                                                <MouseBinding MouseAction="LeftClick" Command="{Binding ToggleSelectionCommand}" />
+                                            </Border.InputBindings>
+                                            <Border.Width>
+                                                <MultiBinding Converter="{StaticResource ColumnWidthConverter}">
+                                                    <Binding ElementName="AccountsScrollViewer" Path="ActualWidth" />
+                                                    <Binding Path="DataContext.Columns" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                                                </MultiBinding>
+                                            </Border.Width>
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Padding" Value="12,6" />
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                        </Trigger>
+                                                        <DataTrigger Binding="{Binding UseCheck}" Value="True">
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+
+                                                <Grid Grid.Row="0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <CheckBox
+                                                        Grid.Column="0"
+                                                        Margin="0,0,8,0"
+                                                        VerticalAlignment="Center"
+                                                        materialDesign:CheckBoxAssist.CheckBoxSize="18"
+                                                        IsChecked="{Binding UseCheck}" />
+
+                                                    <TextBlock
+                                                        Grid.Column="1"
+                                                        FontSize="14"
+                                                        FontWeight="Medium"
+                                                        VerticalAlignment="Center"
+                                                        TextTrimming="CharacterEllipsis"
+                                                        Text="{Binding DisplayName}" />
+
+                                                    <Button
+                                                        Grid.Column="2"
+                                                        Width="24"
+                                                        Height="24"
+                                                        Padding="0"
+                                                        VerticalAlignment="Center"
+                                                        Command="{Binding RemoveCommand}"
+                                                        ToolTip="Remove Account"
+                                                        Background="Transparent"
+                                                        BorderThickness="0">
+                                                        <Button.Style>
+                                                            <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButton}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                                                                <Setter Property="Opacity" Value="0" />
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Border}, Path=IsMouseOver}" Value="True">
+                                                                        <Setter Property="Opacity" Value="1" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Button.Style>
+                                                        <materialDesign:PackIcon Kind="DeleteOutline" Width="14" Height="14" />
+                                                    </Button>
+                                                </Grid>
+
+                                                <ItemsControl
+                                                    Grid.Row="1"
+                                                    ItemsSource="{Binding Tags}"
+                                                    Margin="26,6,0,0">
+                                                    <ItemsControl.Style>
+                                                        <Style TargetType="ItemsControl">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=local:AccountManagerView}, Path=DataContext.ShowTags}" Value="True">
+                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </ItemsControl.Style>
+                                                    <ItemsControl.ItemsPanel>
+                                                        <ItemsPanelTemplate>
+                                                            <WrapPanel />
+                                                        </ItemsPanelTemplate>
+                                                    </ItemsControl.ItemsPanel>
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <Border
+                                                                Background="{DynamicResource PrimaryHueMidBrush}"
+                                                                CornerRadius="2"
+                                                                Padding="4,1"
+                                                                Margin="0,0,3,2"
+                                                                Opacity="0.85">
+                                                                <TextBlock
+                                                                    FontSize="9"
+                                                                    FontWeight="Medium"
+                                                                    Foreground="White"
+                                                                    Text="{Binding}" />
+                                                            </Border>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Grid>
+                    </ScrollViewer>
+                </Grid>
+            </TabItem>
+
+            <!-- Groups Tab -->
+            <TabItem Header="Groups">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <!-- Groups Header -->
+                    <DockPanel Grid.Row="0" Margin="0,6,0,6" LastChildFill="False">
+                        <Button
+                            Height="28"
+                            Padding="6,0"
+                            DockPanel.Dock="Right"
+                            Click="AddGroup_Click"
+                            ToolTip="Create New Group"
+                            Style="{StaticResource MaterialDesignFlatButton}">
+                            <StackPanel Orientation="Horizontal">
+                                <materialDesign:PackIcon Kind="Plus" Width="14" Height="14" VerticalAlignment="Center" />
+                                <TextBlock Text="New Group" FontSize="11" Margin="4,0,0,0" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                    </DockPanel>
+
+                    <!-- Groups List -->
+                    <ScrollViewer
+                        Grid.Row="1"
+                        materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True">
+                        <ItemsControl ItemsSource="{Binding Groups}" Margin="6,0">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <usercontrols:GroupItemUserControl DataContext="{Binding}" Margin="0,0,0,6" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Grid>
+            </TabItem>
+        </TabControl>
+
+        <!-- Start Controls -->
+        <Border
+            Grid.Row="2"
+            Margin="0,6,0,0"
+            Background="{DynamicResource MaterialDesignCardBackground}"
+            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            BorderThickness="1"
+            CornerRadius="4"
+            Padding="8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ComboBox
+                    Grid.Column="0"
+                    Margin="0,0,6,0"
+                    materialDesign:HintAssist.Hint="Login Server"
+                    ItemsSource="{Binding ServerList, UpdateSourceTrigger=PropertyChanged}"
+                    SelectedItem="{Binding SelectedServer}"
+                    Style="{StaticResource MaterialDesignOutlinedComboBox}"
+                    ToolTip="Which server to login when launching accounts" />
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <Button
+                        Margin="6,0,6,0"
+                        Command="{Binding StartAccountsCommand}"
+                        Content="Start Selected"
+                        Style="{StaticResource MaterialDesignRaisedButton}"
+                        ToolTip="Launch and login all the accounts with the checkbox marked" />
+                    <Button
+                        Command="{Binding StartAllAccountsCommand}"
+                        Content="Start All"
+                        Style="{StaticResource MaterialDesignRaisedButton}"
+                        ToolTip="Launch all saved accounts" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Script Section -->
+        <Border
+            Grid.Row="3"
+            Margin="0,6,0,0"
+            Background="{DynamicResource MaterialDesignCardBackground}"
+            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            BorderThickness="1"
+            CornerRadius="4"
+            Padding="8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <DockPanel Grid.Column="0">
+                    <Button
                         VerticalAlignment="Center"
-                        Text="{Binding ScriptPath, FallbackValue='Script Path'}" />
-                </Border>
-            </DockPanel>
-            <CheckBox
-                Grid.Column="1"
-                Margin="6,0,0,0"
-                materialDesign:CheckBoxAssist.CheckBoxSize="24"
-                Content="Start with Script"
-                IsChecked="{Binding StartWithScript}"
-                ToolTip="After launching and logging in to the accounts, starts the specified script." />
-            <Button
-                Grid.Column="2"
-                Margin="6,0,0,0"
-                VerticalAlignment="Center"
-                Command="{Binding OpenGetScriptsCommand}"
-                Content="Search Scripts"
-                ToolTip="Open Search Scripts menu to browse and download scripts" />
-        </Grid>
+                        materialDesign:ButtonAssist.CornerRadius="0"
+                        Command="{Binding OpenGetScriptsCommand}"
+                        Content="{materialDesign:PackIcon Kind=Magnify}"
+                        DockPanel.Dock="Right"
+                        Style="{StaticResource MaterialDesignOutlinedButton}"
+                        ToolTip="Browse and download scripts" />
+                    <Button
+                        VerticalAlignment="Center"
+                        materialDesign:ButtonAssist.CornerRadius="0 4 4 0"
+                        Command="{Binding ChangeScriptPathCommand}"
+                        Content="{materialDesign:PackIcon Kind=Folder}"
+                        DockPanel.Dock="Right"
+                        Style="{StaticResource MaterialDesignOutlinedButton}"
+                        ToolTip="Select script file from folder" />
+                    <Border
+                        Height="40"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}"
+                        BorderThickness="1,1,0,1"
+                        CornerRadius="4 0 0 4"
+                        Background="{DynamicResource MaterialDesignToolBarBackground}"
+                        ToolTip="Path to a script which will be loaded and started after launching an account">
+                        <TextBlock
+                            Margin="12,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="{Binding ScriptPath, FallbackValue='No script selected'}"
+                            Foreground="{DynamicResource MaterialDesignBody}" />
+                    </Border>
+                </DockPanel>
+                <CheckBox
+                    Grid.Column="1"
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Center"
+                    materialDesign:CheckBoxAssist.CheckBoxSize="20"
+                    Content="Auto-start"
+                    IsChecked="{Binding StartWithScript}"
+                    ToolTip="After launching and logging in to the accounts, starts the specified script" />
+            </Grid>
+        </Border>
     </Grid>
 </UserControl>

--- a/Skua.WPF/Views/AccountManager.xaml
+++ b/Skua.WPF/Views/AccountManager.xaml
@@ -163,7 +163,7 @@
                     </Grid.RowDefinitions>
 
                     <!-- Accounts Header with Controls -->
-                    <Grid Grid.Row="0" Margin="0,4,0,6">
+                    <Grid Grid.Row="0" Margin="0,6,0,6">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
@@ -220,7 +220,7 @@
 
                         <ToggleButton
                             x:Name="FilterButton"
-                            Grid.Column="3"
+                            Grid.Column="4"
                             Width="32"
                             Height="32"
                             Margin="0,0,8,0"
@@ -303,7 +303,7 @@
                         </Popup>
 
                         <ToggleButton
-                            Grid.Column="4"
+                            Grid.Column="5"
                             Width="32"
                             Height="32"
                             Margin="0,0,8,0"
@@ -320,7 +320,7 @@
                         </ToggleButton>
 
                         <ToggleButton
-                            Grid.Column="5"
+                            Grid.Column="6"
                             Width="32"
                             Height="32"
                             Margin="0,0,8,0"
@@ -338,7 +338,7 @@
 
                         <Button
                             x:Name="ShowAddAccountButton"
-                            Grid.Column="6"
+                            Grid.Column="3"
                             Height="32"
                             Padding="8,4"
                             VerticalAlignment="Center"
@@ -570,84 +570,81 @@
         </TabControl>
 
         <!-- Start Controls -->
-        <Border
-            Grid.Row="2"
-            Margin="0,6,0,0"
-            Background="{DynamicResource MaterialDesignCardBackground}"
-            BorderBrush="{DynamicResource MaterialDesignDivider}"
-            BorderThickness="1"
-            CornerRadius="4"
-            Padding="8">
-            <Grid>
+            <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <ComboBox
-                    Grid.Column="0"
-                    Margin="0,0,6,0"
-                    materialDesign:HintAssist.Hint="Login Server"
-                    ItemsSource="{Binding ServerList, UpdateSourceTrigger=PropertyChanged}"
-                    SelectedItem="{Binding SelectedServer}"
-                    Style="{StaticResource MaterialDesignOutlinedComboBox}"
-                    ToolTip="Which server to login when launching accounts">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="{Binding Name}" FontWeight="Medium" />
-                                <TextBlock Opacity="0.6" FontWeight="Medium">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Upgrade}" Value="True">
-                                                    <Setter Property="Text" Value=" [M]" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <TextBlock Text=" - " Opacity="0.6" />
-                                <TextBlock Opacity="0.6">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="{Binding Ping, StringFormat='{}{0}ms'}" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Online}" Value="False">
-                                                    <Setter Property="Text" Value="Offline" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Ping}" Value="-1">
-                                                    <Setter Property="Text" Value="..." />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Ping}" Value="9999">
-                                                    <Setter Property="Text" Value="timeout" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                <StackPanel Margin="6,0,6,0">
+                    <ComboBox
+                        Grid.Column="0"
+                        materialDesign:HintAssist.Hint="Login Server"
+                        ItemsSource="{Binding ServerList, UpdateSourceTrigger=PropertyChanged}"
+                        SelectedItem="{Binding SelectedServer}"
+                        Style="{StaticResource MaterialDesignOutlinedComboBox}"
+                        ToolTip="Which server to login when launching accounts">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
-                                    <StackPanel.Style>
-                                        <Style TargetType="StackPanel">
-                                            <Setter Property="Visibility" Value="Visible" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Online}" Value="False">
-                                                    <Setter Property="Visibility" Value="Collapsed" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </StackPanel.Style>
+                                    <TextBlock Text="{Binding Name}" FontWeight="Medium" />
+                                    <TextBlock Opacity="0.6" FontWeight="Medium">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Upgrade}" Value="True">
+                                                        <Setter Property="Text" Value=" [M]" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
                                     <TextBlock Text=" - " Opacity="0.6" />
                                     <TextBlock Opacity="0.6">
-                                        <Run Text="{Binding PlayerCount, Mode=OneWay}" />
-                                        <Run Text="/" />
-                                        <Run Text="{Binding MaxPlayers, Mode=OneWay}" />
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="{Binding Ping, StringFormat='{}{0}ms'}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Online}" Value="False">
+                                                        <Setter Property="Text" Value="Offline" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Ping}" Value="-1">
+                                                        <Setter Property="Text" Value="..." />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Ping}" Value="9999">
+                                                        <Setter Property="Text" Value="timeout" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
                                     </TextBlock>
+                                    <StackPanel Orientation="Horizontal">
+                                        <StackPanel.Style>
+                                            <Style TargetType="StackPanel">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Online}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </StackPanel.Style>
+                                        <TextBlock Text=" - " Opacity="0.6" />
+                                        <TextBlock Opacity="0.6">
+                                            <Run Text="{Binding PlayerCount, Mode=OneWay}" />
+                                            <Run Text="/" />
+                                            <Run Text="{Binding MaxPlayers, Mode=OneWay}" />
+                                        </TextBlock>
+                                    </StackPanel>
                                 </StackPanel>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                </ComboBox>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </StackPanel>
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <Button
                         Margin="6,0,6,0"
@@ -661,25 +658,24 @@
                         Style="{StaticResource MaterialDesignRaisedButton}"
                         ToolTip="Launch all saved accounts" />
                 </StackPanel>
-            </Grid>
-        </Border>
-
-        <!-- Script Section -->
-        <Border
-            Grid.Row="3"
-            Margin="0,6,0,0"
-            Background="{DynamicResource MaterialDesignCardBackground}"
-            BorderBrush="{DynamicResource MaterialDesignDivider}"
-            BorderThickness="1"
-            CornerRadius="4"
-            Padding="8">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <DockPanel Grid.Column="0">
-                    <Button
+            <StackPanel Grid.Row="1" Margin="6,6,0,6">
+                <Border
+                        Height="40"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}"
+                        BorderThickness="1,1,0,1"
+                        CornerRadius="4 0 0 4"
+                        Background="{DynamicResource MaterialDesignToolBarBackground}"
+                        ToolTip="Path to a script which will be loaded and started after launching an account">
+                    <TextBlock
+                            Margin="12,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="{Binding ScriptPath, FallbackValue='No script selected'}"
+                            Foreground="{DynamicResource MaterialDesignBody}" />
+                </Border>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal">
+                <DockPanel>
+                        <Button
                         Height="40"
                         VerticalAlignment="Center"
                         materialDesign:ButtonAssist.CornerRadius="0"
@@ -688,7 +684,7 @@
                         DockPanel.Dock="Right"
                         Style="{StaticResource MaterialDesignOutlinedButton}"
                         ToolTip="Browse and download scripts" />
-                    <Button
+                        <Button
                         Height="40"
                         VerticalAlignment="Center"
                         materialDesign:ButtonAssist.CornerRadius="0"
@@ -697,29 +693,15 @@
                         DockPanel.Dock="Right"
                         Style="{StaticResource MaterialDesignOutlinedButton}"
                         ToolTip="Select script file from folder" />
-                    <Border
-                        Height="40"
-                        BorderBrush="{DynamicResource MaterialDesignDivider}"
-                        BorderThickness="1,1,0,1"
-                        CornerRadius="4 0 0 4"
-                        Background="{DynamicResource MaterialDesignToolBarBackground}"
-                        ToolTip="Path to a script which will be loaded and started after launching an account">
-                        <TextBlock
-                            Margin="12,0,0,0"
-                            VerticalAlignment="Center"
-                            Text="{Binding ScriptPath, FallbackValue='No script selected'}"
-                            Foreground="{DynamicResource MaterialDesignBody}" />
-                    </Border>
-                </DockPanel>
-                <CheckBox
-                    Grid.Column="1"
-                    Margin="12,0,0,0"
-                    VerticalAlignment="Center"
-                    materialDesign:CheckBoxAssist.CheckBoxSize="20"
-                    Content="Auto-start"
-                    IsChecked="{Binding StartWithScript}"
-                    ToolTip="After launching and logging in to the accounts, starts the specified script" />
+                    </DockPanel>
+                    <CheckBox
+                     Margin="12,0,0,0"
+                     VerticalAlignment="Center"
+                     materialDesign:CheckBoxAssist.CheckBoxSize="20"
+                     Content="Auto-start"
+                     IsChecked="{Binding StartWithScript}"
+                     ToolTip="After launching and logging in to the accounts, starts the specified script" />
+                </StackPanel>
             </Grid>
-        </Border>
     </Grid>
 </UserControl>

--- a/Skua.WPF/Views/AccountManager.xaml
+++ b/Skua.WPF/Views/AccountManager.xaml
@@ -163,8 +163,9 @@
                     </Grid.RowDefinitions>
 
                     <!-- Accounts Header with Controls -->
-                    <Grid Grid.Row="0" Margin="0,6,0,6">
+                    <Grid Grid.Row="0" Margin="0,4,0,6">
                         <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
@@ -176,7 +177,7 @@
 
                         <TextBlock
                             Grid.Column="0"
-                            Margin="0,0,12,0"
+                            Margin="0,0,8,0"
                             VerticalAlignment="Center"
                             FontSize="14"
                             Text="{Binding SelectedAccountQuant, StringFormat='Selected: {0}'}">
@@ -192,9 +193,49 @@
                             </TextBlock.Style>
                         </TextBlock>
 
+                        <Button
+                            Grid.Column="1"
+                            Height="28"
+                            Padding="6,4"
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            Command="{Binding RemoveAccountsCommand}"
+                            ToolTip="Remove Selected">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignFlatButton}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SelectedAccountQuant, Converter={StaticResource IntToBooleanConverter}}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <StackPanel Orientation="Horizontal">
+                                <materialDesign:PackIcon Kind="DeleteOutline" Width="12" Height="12" VerticalAlignment="Center" />
+                                <TextBlock Text="Remove Selected" FontSize="11" Margin="4,0,0,0" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <Button
+                            x:Name="ShowAddAccountButton"
+                            Grid.Column="3"
+                            Height="32"
+                            Padding="8,4"
+                            Margin="0,0,8,0"
+                            VerticalAlignment="Center"
+                            Click="ShowAddAccountButton_Click"
+                            ToolTip="Add Account"
+                            Style="{StaticResource MaterialDesignFlatButton}">
+                            <StackPanel Orientation="Horizontal">
+                                <materialDesign:PackIcon Kind="Plus" Width="14" Height="14" VerticalAlignment="Center" />
+                                <TextBlock Text="Add Account" FontSize="11" Margin="4,0,0,0" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
                         <ComboBox
                             x:Name="ColumnsComboBox"
-                            Grid.Column="2"
+                            Grid.Column="4"
                             Width="45"
                             Margin="0,0,8,0"
                             VerticalAlignment="Center"
@@ -220,7 +261,7 @@
 
                         <ToggleButton
                             x:Name="FilterButton"
-                            Grid.Column="4"
+                            Grid.Column="5"
                             Width="32"
                             Height="32"
                             Margin="0,0,8,0"
@@ -303,7 +344,7 @@
                         </Popup>
 
                         <ToggleButton
-                            Grid.Column="5"
+                            Grid.Column="6"
                             Width="32"
                             Height="32"
                             Margin="0,0,8,0"
@@ -320,7 +361,7 @@
                         </ToggleButton>
 
                         <ToggleButton
-                            Grid.Column="6"
+                            Grid.Column="7"
                             Width="32"
                             Height="32"
                             Margin="0,0,8,0"
@@ -335,21 +376,6 @@
                                 <materialDesign:PackIcon Kind="ViewGrid" Width="16" Height="16" />
                             </materialDesign:ToggleButtonAssist.OnContent>
                         </ToggleButton>
-
-                        <Button
-                            x:Name="ShowAddAccountButton"
-                            Grid.Column="3"
-                            Height="32"
-                            Padding="8,4"
-                            VerticalAlignment="Center"
-                            Click="ShowAddAccountButton_Click"
-                            ToolTip="Add Account"
-                            Style="{StaticResource MaterialDesignFlatButton}">
-                            <StackPanel Orientation="Horizontal">
-                                <materialDesign:PackIcon Kind="Plus" Width="14" Height="14" VerticalAlignment="Center" />
-                                <TextBlock Text="Add Account" FontSize="11" Margin="4,0,0,0" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
                     </Grid>
 
                     <!-- Accounts List/Grid View -->
@@ -466,19 +492,7 @@
                                                         VerticalAlignment="Center"
                                                         Command="{Binding RemoveCommand}"
                                                         ToolTip="Remove Account"
-                                                        Background="Transparent"
-                                                        BorderThickness="0">
-                                                        <Button.Style>
-                                                            <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignIconButton}">
-                                                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
-                                                                <Setter Property="Opacity" Value="0" />
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Border}, Path=IsMouseOver}" Value="True">
-                                                                        <Setter Property="Opacity" Value="1" />
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </Button.Style>
+                                                        Style="{StaticResource MaterialDesignIconButton}">
                                                         <materialDesign:PackIcon Kind="DeleteOutline" Width="14" Height="14" />
                                                     </Button>
                                                 </Grid>
@@ -570,81 +584,81 @@
         </TabControl>
 
         <!-- Start Controls -->
-            <Grid Grid.Row="2">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+        <Border
+            Grid.Row="2"
+            Background="{DynamicResource MaterialDesignCardBackground}"
+            BorderThickness="0"
+            Padding="8,4">
+            <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="2*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <StackPanel Margin="6,0,6,0">
-                    <ComboBox
-                        Grid.Column="0"
-                        materialDesign:HintAssist.Hint="Login Server"
-                        ItemsSource="{Binding ServerList, UpdateSourceTrigger=PropertyChanged}"
-                        SelectedItem="{Binding SelectedServer}"
-                        Style="{StaticResource MaterialDesignOutlinedComboBox}"
-                        ToolTip="Which server to login when launching accounts">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate>
+                <ComboBox
+                    Grid.Column="0"
+                    Margin="0,0,6,0"
+                    materialDesign:HintAssist.Hint="Login Server"
+                    ItemsSource="{Binding ServerList, UpdateSourceTrigger=PropertyChanged}"
+                    SelectedItem="{Binding SelectedServer}"
+                    Style="{StaticResource MaterialDesignFloatingHintComboBox}"
+                    ToolTip="Which server to login when launching accounts">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Name}" FontWeight="Medium" />
+                                <TextBlock Opacity="0.6" FontWeight="Medium">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Upgrade}" Value="True">
+                                                    <Setter Property="Text" Value=" [M]" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBlock Text=" - " Opacity="0.6" />
+                                <TextBlock Opacity="0.6">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="{Binding Ping, StringFormat='{}{0}ms'}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Online}" Value="False">
+                                                    <Setter Property="Text" Value="Offline" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Ping}" Value="-1">
+                                                    <Setter Property="Text" Value="..." />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Ping}" Value="9999">
+                                                    <Setter Property="Text" Value="timeout" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding Name}" FontWeight="Medium" />
-                                    <TextBlock Opacity="0.6" FontWeight="Medium">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Text" Value="" />
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Upgrade}" Value="True">
-                                                        <Setter Property="Text" Value=" [M]" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Online}" Value="False">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
                                     <TextBlock Text=" - " Opacity="0.6" />
                                     <TextBlock Opacity="0.6">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Text" Value="{Binding Ping, StringFormat='{}{0}ms'}" />
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Online}" Value="False">
-                                                        <Setter Property="Text" Value="Offline" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding Ping}" Value="-1">
-                                                        <Setter Property="Text" Value="..." />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding Ping}" Value="9999">
-                                                        <Setter Property="Text" Value="timeout" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
+                                        <Run Text="{Binding PlayerCount, Mode=OneWay}" />
+                                        <Run Text="/" />
+                                        <Run Text="{Binding MaxPlayers, Mode=OneWay}" />
                                     </TextBlock>
-                                    <StackPanel Orientation="Horizontal">
-                                        <StackPanel.Style>
-                                            <Style TargetType="StackPanel">
-                                                <Setter Property="Visibility" Value="Visible" />
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Online}" Value="False">
-                                                        <Setter Property="Visibility" Value="Collapsed" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </StackPanel.Style>
-                                        <TextBlock Text=" - " Opacity="0.6" />
-                                        <TextBlock Opacity="0.6">
-                                            <Run Text="{Binding PlayerCount, Mode=OneWay}" />
-                                            <Run Text="/" />
-                                            <Run Text="{Binding MaxPlayers, Mode=OneWay}" />
-                                        </TextBlock>
-                                    </StackPanel>
                                 </StackPanel>
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
-                </StackPanel>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <Button
                         Margin="6,0,6,0"
@@ -658,24 +672,22 @@
                         Style="{StaticResource MaterialDesignRaisedButton}"
                         ToolTip="Launch all saved accounts" />
                 </StackPanel>
-            <StackPanel Grid.Row="1" Margin="6,6,0,6">
-                <Border
-                        Height="40"
-                        BorderBrush="{DynamicResource MaterialDesignDivider}"
-                        BorderThickness="1,1,0,1"
-                        CornerRadius="4 0 0 4"
-                        Background="{DynamicResource MaterialDesignToolBarBackground}"
-                        ToolTip="Path to a script which will be loaded and started after launching an account">
-                    <TextBlock
-                            Margin="12,0,0,0"
-                            VerticalAlignment="Center"
-                            Text="{Binding ScriptPath, FallbackValue='No script selected'}"
-                            Foreground="{DynamicResource MaterialDesignBody}" />
-                </Border>
-            </StackPanel>
-            <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal">
-                <DockPanel>
-                        <Button
+            </Grid>
+        </Border>
+
+        <!-- Script Section -->
+        <Border
+            Grid.Row="3"
+            Background="{DynamicResource MaterialDesignCardBackground}"
+            BorderThickness="0"
+            Padding="8,4">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <DockPanel Grid.Column="0">
+                    <Button
                         Height="40"
                         VerticalAlignment="Center"
                         materialDesign:ButtonAssist.CornerRadius="0"
@@ -684,7 +696,7 @@
                         DockPanel.Dock="Right"
                         Style="{StaticResource MaterialDesignOutlinedButton}"
                         ToolTip="Browse and download scripts" />
-                        <Button
+                    <Button
                         Height="40"
                         VerticalAlignment="Center"
                         materialDesign:ButtonAssist.CornerRadius="0"
@@ -693,15 +705,29 @@
                         DockPanel.Dock="Right"
                         Style="{StaticResource MaterialDesignOutlinedButton}"
                         ToolTip="Select script file from folder" />
-                    </DockPanel>
-                    <CheckBox
-                     Margin="12,0,0,0"
-                     VerticalAlignment="Center"
-                     materialDesign:CheckBoxAssist.CheckBoxSize="20"
-                     Content="Auto-start"
-                     IsChecked="{Binding StartWithScript}"
-                     ToolTip="After launching and logging in to the accounts, starts the specified script" />
-                </StackPanel>
+                    <Border
+                        Height="40"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}"
+                        BorderThickness="1,1,0,1"
+                        CornerRadius="4 0 0 4"
+                        Background="{DynamicResource MaterialDesignToolBarBackground}"
+                        ToolTip="Path to a script which will be loaded and started after launching an account">
+                        <TextBlock
+                            Margin="12,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="{Binding ScriptPath, FallbackValue='No script selected'}"
+                            Foreground="{DynamicResource MaterialDesignBody}" />
+                    </Border>
+                </DockPanel>
+                <CheckBox
+                    Grid.Column="1"
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Center"
+                    materialDesign:CheckBoxAssist.CheckBoxSize="20"
+                    Content="Auto-start"
+                    IsChecked="{Binding StartWithScript}"
+                    ToolTip="After launching and logging in to the accounts, starts the specified script" />
             </Grid>
+        </Border>
     </Grid>
 </UserControl>

--- a/Skua.WPF/Views/AccountManager.xaml
+++ b/Skua.WPF/Views/AccountManager.xaml
@@ -356,10 +356,10 @@
                     <ScrollViewer
                         x:Name="AccountsScrollViewer"
                         Grid.Row="1"
-                        Padding="4"
+                        Padding="4,4,4,4"
                         materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True"
                         ContextMenu="{StaticResource BulkAccountContextMenu}">
-                        <Grid>
+                            <Grid>
                             <!-- List View -->
                             <ItemsControl
                                 ItemsSource="{Binding FilteredAccounts}">
@@ -401,7 +401,7 @@
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
                                         <Border
-                                            Margin="0,0,6,6"
+                                            Margin="0,0,4,4"
                                             Background="{DynamicResource MaterialDesignCardBackground}"
                                             BorderBrush="{DynamicResource MaterialDesignDivider}"
                                             BorderThickness="2"
@@ -590,7 +590,64 @@
                     ItemsSource="{Binding ServerList, UpdateSourceTrigger=PropertyChanged}"
                     SelectedItem="{Binding SelectedServer}"
                     Style="{StaticResource MaterialDesignOutlinedComboBox}"
-                    ToolTip="Which server to login when launching accounts" />
+                    ToolTip="Which server to login when launching accounts">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Name}" FontWeight="Medium" />
+                                <TextBlock Opacity="0.6" FontWeight="Medium">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Upgrade}" Value="True">
+                                                    <Setter Property="Text" Value=" [M]" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBlock Text=" - " Opacity="0.6" />
+                                <TextBlock Opacity="0.6">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="{Binding Ping, StringFormat='{}{0}ms'}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Online}" Value="False">
+                                                    <Setter Property="Text" Value="Offline" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Ping}" Value="-1">
+                                                    <Setter Property="Text" Value="..." />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Ping}" Value="9999">
+                                                    <Setter Property="Text" Value="timeout" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Online}" Value="False">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+                                    <TextBlock Text=" - " Opacity="0.6" />
+                                    <TextBlock Opacity="0.6">
+                                        <Run Text="{Binding PlayerCount, Mode=OneWay}" />
+                                        <Run Text="/" />
+                                        <Run Text="{Binding MaxPlayers, Mode=OneWay}" />
+                                    </TextBlock>
+                                </StackPanel>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <Button
                         Margin="6,0,6,0"
@@ -623,6 +680,7 @@
                 </Grid.ColumnDefinitions>
                 <DockPanel Grid.Column="0">
                     <Button
+                        Height="40"
                         VerticalAlignment="Center"
                         materialDesign:ButtonAssist.CornerRadius="0"
                         Command="{Binding OpenGetScriptsCommand}"
@@ -631,8 +689,9 @@
                         Style="{StaticResource MaterialDesignOutlinedButton}"
                         ToolTip="Browse and download scripts" />
                     <Button
+                        Height="40"
                         VerticalAlignment="Center"
-                        materialDesign:ButtonAssist.CornerRadius="0 4 4 0"
+                        materialDesign:ButtonAssist.CornerRadius="0"
                         Command="{Binding ChangeScriptPathCommand}"
                         Content="{materialDesign:PackIcon Kind=Folder}"
                         DockPanel.Dock="Right"

--- a/Skua.WPF/Views/AccountManager.xaml.cs
+++ b/Skua.WPF/Views/AccountManager.xaml.cs
@@ -84,7 +84,7 @@ public sealed partial class AccountManagerView : UserControl
             return;
         }
 
-        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+        InputDialogViewModel inputDialogViewModel = new(
             "Add Tags to Selected", "Enter tags (comma-separated)", "Tags", numericInputOnly: false);
         bool? result = dialogService.ShowDialog(inputDialogViewModel, "Add Tags");
 
@@ -112,7 +112,7 @@ public sealed partial class AccountManagerView : UserControl
     public void EditAccountTags(AccountItemViewModel account)
     {
         string existingTags = string.Join(", ", account.Tags);
-        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+        InputDialogViewModel inputDialogViewModel = new(
             "Edit Tags", "Enter tags (comma-separated)", "Tags", numericInputOnly: false)
         {
             DialogTextInput = existingTags
@@ -146,7 +146,7 @@ public sealed partial class AccountManagerView : UserControl
             return;
         }
 
-        SelectGroupDialogViewModel dialogViewModel = new SelectGroupDialogViewModel(viewModel.Groups);
+        SelectGroupDialogViewModel dialogViewModel = new(viewModel.Groups);
         bool? result = dialogService.ShowDialog(dialogViewModel, "Add Selected to Group");
 
         if (result == true && dialogViewModel.SelectedGroup != null)
@@ -160,7 +160,7 @@ public sealed partial class AccountManagerView : UserControl
 
     private void AddAccountToGroup(AccountItemViewModel account)
     {
-        SelectGroupDialogViewModel dialogViewModel = new SelectGroupDialogViewModel(viewModel.Groups);
+        SelectGroupDialogViewModel dialogViewModel = new(viewModel.Groups);
         bool? result = dialogService.ShowDialog(dialogViewModel, "Add to Group");
 
         if (result == true && dialogViewModel.SelectedGroup != null)
@@ -171,7 +171,7 @@ public sealed partial class AccountManagerView : UserControl
 
     private void AddGroup_Click(object sender, RoutedEventArgs e)
     {
-        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+        InputDialogViewModel inputDialogViewModel = new(
             "Create Group", "Enter group name", "Group Name", numericInputOnly: false);
         bool? result = dialogService.ShowDialog(inputDialogViewModel, "Create Group");
 

--- a/Skua.WPF/Views/AccountManager.xaml.cs
+++ b/Skua.WPF/Views/AccountManager.xaml.cs
@@ -1,7 +1,11 @@
-﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Messaging;
+using Skua.Core.Interfaces;
 using Skua.Core.Messaging;
+using Skua.Core.ViewModels;
 using Skua.Core.ViewModels.Manager;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -12,17 +16,38 @@ namespace Skua.WPF.Views;
 /// </summary>
 public sealed partial class AccountManagerView : UserControl
 {
+    private readonly AccountManagerViewModel viewModel;
+    private readonly IDialogService dialogService;
+
     public AccountManagerView()
     {
         InitializeComponent();
-        DataContext = Ioc.Default.GetRequiredService<AccountManagerViewModel>();
+        viewModel = Ioc.Default.GetRequiredService<AccountManagerViewModel>();
+        dialogService = Ioc.Default.GetRequiredService<IDialogService>();
+        DataContext = viewModel;
+
+        // Set initial ComboBox selection based on ViewModel
+        ColumnsComboBox.SelectedIndex = viewModel.Columns - 1;
+
+        // Subscribe to property changes to keep ComboBox in sync
+        viewModel.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(viewModel.Columns))
+            {
+                ColumnsComboBox.SelectedIndex = viewModel.Columns - 1;
+            }
+        };
+
         StrongReferenceMessenger.Default.Register<AccountManagerView, ClearPasswordBoxMessage>(this, ClearPasswordBox);
+        WeakReferenceMessenger.Default.Register<AccountManagerView, AddAccountToGroupMessage>(this, (r, m) => r.AddAccountToGroup(m.Account));
+        WeakReferenceMessenger.Default.Register<AccountManagerView, AddTagsMessage>(this, (r, m) => r.EditAccountTags(m.Account));
         Unloaded += OnUnloaded;
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         StrongReferenceMessenger.Default.UnregisterAll(this);
+        WeakReferenceMessenger.Default.UnregisterAll(this);
         Unloaded -= OnUnloaded;
     }
 
@@ -31,8 +56,137 @@ public sealed partial class AccountManagerView : UserControl
         PswBox?.Clear();
     }
 
+    // Account Form Events
     private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
     {
         ((AccountManagerViewModel)DataContext).PasswordInput = ((PasswordBox)sender).Password;
+    }
+
+    private void ShowAddAccountButton_Click(object sender, RoutedEventArgs e)
+    {
+        ShowAddAccountButton.Visibility = Visibility.Collapsed;
+        AddAccountForm.Visibility = Visibility.Visible;
+    }
+
+    private void HideAddAccountButton_Click(object sender, RoutedEventArgs e)
+    {
+        ShowAddAccountButton.Visibility = Visibility.Visible;
+        AddAccountForm.Visibility = Visibility.Collapsed;
+    }
+
+    // Tag Management
+    private void AddTagsToSelected_Click(object sender, RoutedEventArgs e)
+    {
+        List<AccountItemViewModel> selectedAccounts = viewModel.Accounts.Where(a => a.UseCheck).ToList();
+        if (!selectedAccounts.Any())
+        {
+            dialogService.ShowMessageBox("No accounts selected", "Add Tags");
+            return;
+        }
+
+        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+            "Add Tags to Selected", "Enter tags (comma-separated)", "Tags", numericInputOnly: false);
+        bool? result = dialogService.ShowDialog(inputDialogViewModel, "Add Tags");
+
+        if (result == true)
+        {
+            List<string> tags = inputDialogViewModel.DialogTextInput.Split(',')
+                .Select(t => t.Trim()).Where(t => !string.IsNullOrWhiteSpace(t))
+                .Distinct().ToList();
+
+            foreach (AccountItemViewModel account in selectedAccounts)
+            {
+                foreach (string tag in tags)
+                {
+                    if (!account.Tags.Contains(tag))
+                        account.Tags.Add(tag);
+                }
+            }
+
+            viewModel.SaveAccounts();
+            viewModel.RefreshTagFilters();
+            viewModel.ApplyTagFilter();
+        }
+    }
+
+    public void EditAccountTags(AccountItemViewModel account)
+    {
+        string existingTags = string.Join(", ", account.Tags);
+        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+            "Edit Tags", "Enter tags (comma-separated)", "Tags", numericInputOnly: false)
+        {
+            DialogTextInput = existingTags
+        };
+
+        bool? result = dialogService.ShowDialog(inputDialogViewModel, "Edit Tags");
+
+        if (result == true)
+        {
+            List<string> newTags = inputDialogViewModel.DialogTextInput.Split(',')
+                .Select(t => t.Trim()).Where(t => !string.IsNullOrWhiteSpace(t))
+                .Distinct().ToList();
+
+            account.Tags.Clear();
+            foreach (string tag in newTags)
+                account.Tags.Add(tag);
+
+            viewModel.SaveAccounts();
+            viewModel.RefreshTagFilters();
+            viewModel.ApplyTagFilter();
+        }
+    }
+
+    // Group Management
+    private void AddSelectedToGroup_Click(object sender, RoutedEventArgs e)
+    {
+        List<AccountItemViewModel> selectedAccounts = viewModel.Accounts.Where(a => a.UseCheck).ToList();
+        if (!selectedAccounts.Any())
+        {
+            dialogService.ShowMessageBox("No accounts selected", "Add to Group");
+            return;
+        }
+
+        SelectGroupDialogViewModel dialogViewModel = new SelectGroupDialogViewModel(viewModel.Groups);
+        bool? result = dialogService.ShowDialog(dialogViewModel, "Add Selected to Group");
+
+        if (result == true && dialogViewModel.SelectedGroup != null)
+        {
+            foreach (AccountItemViewModel account in selectedAccounts)
+            {
+                viewModel.AddAccountToGroup(account, dialogViewModel.SelectedGroup);
+            }
+        }
+    }
+
+    private void AddAccountToGroup(AccountItemViewModel account)
+    {
+        SelectGroupDialogViewModel dialogViewModel = new SelectGroupDialogViewModel(viewModel.Groups);
+        bool? result = dialogService.ShowDialog(dialogViewModel, "Add to Group");
+
+        if (result == true && dialogViewModel.SelectedGroup != null)
+        {
+            viewModel.AddAccountToGroup(account, dialogViewModel.SelectedGroup);
+        }
+    }
+
+    private void AddGroup_Click(object sender, RoutedEventArgs e)
+    {
+        InputDialogViewModel inputDialogViewModel = new InputDialogViewModel(
+            "Create Group", "Enter group name", "Group Name", numericInputOnly: false);
+        bool? result = dialogService.ShowDialog(inputDialogViewModel, "Create Group");
+
+        if (result == true && !string.IsNullOrWhiteSpace(inputDialogViewModel.DialogTextInput))
+        {
+            viewModel.AddGroup(inputDialogViewModel.DialogTextInput.Trim());
+        }
+    }
+
+    // Grid View
+    private void ColumnsComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (sender is ComboBox comboBox && comboBox.SelectedIndex >= 0 && viewModel != null)
+        {
+            viewModel.Columns = comboBox.SelectedIndex + 1;
+        }
     }
 }

--- a/Skua.WPF/Views/ChangeLogsView.xaml
+++ b/Skua.WPF/Views/ChangeLogsView.xaml
@@ -25,8 +25,8 @@
             x:Name="Markdownview"
             Grid.Row="0"
             Foreground="White"
-            FontFamily="Cambria"
             Margin="20,10,0,20"
+            DataContextChanged="Markdownview_DataContextChanged"
             Markdown="{Binding MarkdownDoc, UpdateSourceTrigger=PropertyChanged}" />
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>

--- a/Skua.WPF/XAML/Converters.xaml
+++ b/Skua.WPF/XAML/Converters.xaml
@@ -13,4 +13,5 @@
     <converters:MultiValueEqualityConverter x:Key="MultiValueEqualityConverter" />
     <converters:EqualToConverter x:Key="EqualToConverter" />
     <converters:GreaterThanConverter x:Key="GreaterThanConverter" />
+    <converters:ColumnWidthConverter x:Key="ColumnWidthConverter" />
 </ResourceDictionary>

--- a/Skua.WPF/XAML/DataTemplates.xaml
+++ b/Skua.WPF/XAML/DataTemplates.xaml
@@ -141,4 +141,7 @@
     <DataTemplate DataType="{x:Type managerVms:AccountManagerViewModel}">
         <views:AccountManagerView />
     </DataTemplate>
+    <DataTemplate DataType="{x:Type managerVms:SelectGroupDialogViewModel}">
+        <usercontrols:SelectGroupDialog />
+    </DataTemplate>
 </ResourceDictionary>


### PR DESCRIPTION
Main Changes
- Add 'Groups': Add a tab to the Account manager that allows the creation of 'Groups'. Predefined collection of accounts. You may add accounts to groups and launch them at the same time. Stores in skua.settings.json
- Grid View: Replaced the old grid view
- Tag Filtering: You can now search accounts using tags
- Selection: Rather than using the checkbox you can just click on the card
- Context Menu: Added context menu on right click
