### PR TITLE
Added a toggle to Advanced Skills to reset on target change

### DIFF
--- a/Skua.Core.Interfaces/Skills/ISkillProvider.cs
+++ b/Skua.Core.Interfaces/Skills/ISkillProvider.cs
@@ -36,7 +36,7 @@ public interface ISkillProvider
     /// <summary>
     /// This method is called when the target is reset/changed.
     /// </summary>
-    void OnTargetReset();
+    bool OnTargetReset();
 
     /// <summary>
     /// This method is called when the player dies.

--- a/Skua.Core.Interfaces/Skills/ISkillProvider.cs
+++ b/Skua.Core.Interfaces/Skills/ISkillProvider.cs
@@ -34,8 +34,12 @@ public interface ISkillProvider
     (int, int) GetNextSkill();
 
     /// <summary>
-    /// This method is called when the target is reset/changed.
+    /// Checks whether the current target has been lost or changed and resets provider state if needed.
     /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the provider reset its skill state and the current skill attempt should be aborted;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
     bool OnTargetReset();
 
     /// <summary>

--- a/Skua.Core.Models/Skills/AdvancedSkill.cs
+++ b/Skua.Core.Models/Skills/AdvancedSkill.cs
@@ -55,7 +55,7 @@ public class AdvancedSkill
 
     public override string ToString()
     {
-        return $"{ClassUseMode} : {ClassName} = {Skills} [{(SkillUseMode == SkillUseMode.UseIfAvailable ? "Use if Available" : "Wait for Cooldown")}]";
+        return $"{ClassUseMode} : {ClassName} = {Skills} [{(SkillUseMode == SkillUseMode.UseIfAvailable ? "Use if Available" : "Wait for Cooldown")}]{(ResetComboOnTargetChange ? " [Reset on Target Change]" : string.Empty)}";
     }
 
     public override bool Equals(object? obj)

--- a/Skua.Core.Models/Skills/AdvancedSkill.cs
+++ b/Skua.Core.Models/Skills/AdvancedSkill.cs
@@ -5,40 +5,44 @@ public class AdvancedSkill
     public AdvancedSkill()
     { }
 
-    public AdvancedSkill(string className, string skills, int skillTimeout = -1, string classUseMode = "Base", string skillUseMode = "UseIfAvailable")
+    public AdvancedSkill(string className, string skills, int skillTimeout = -1, string classUseMode = "Base", string skillUseMode = "UseIfAvailable", bool resetComboOnTargetChange = false)
     {
         ClassName = className;
         Skills = skills;
         SkillTimeout = skillTimeout;
         ClassUseMode = (ClassUseMode)Enum.Parse(typeof(ClassUseMode), classUseMode, ignoreCase: true);
         SkillUseMode = (SkillUseMode)Enum.Parse(typeof(SkillUseMode), skillUseMode, ignoreCase: true);
+        ResetComboOnTargetChange = resetComboOnTargetChange;
     }
 
-    public AdvancedSkill(string className, string skills, int skillTimeout = -1, int classUseMode = 0, SkillUseMode skillUseMode = SkillUseMode.UseIfAvailable)
+    public AdvancedSkill(string className, string skills, int skillTimeout = -1, int classUseMode = 0, SkillUseMode skillUseMode = SkillUseMode.UseIfAvailable, bool resetComboOnTargetChange = false)
     {
         ClassName = className;
         Skills = skills;
         SkillTimeout = skillTimeout;
         ClassUseMode = (ClassUseMode)classUseMode;
         SkillUseMode = skillUseMode;
+        ResetComboOnTargetChange = resetComboOnTargetChange;
     }
 
-    public AdvancedSkill(string className, string skills, int skillTimeout, ClassUseMode classUseMode, SkillUseMode skillUseMode)
+    public AdvancedSkill(string className, string skills, int skillTimeout, ClassUseMode classUseMode, SkillUseMode skillUseMode, bool resetComboOnTargetChange = false)
     {
         ClassName = className;
         Skills = skills;
         SkillTimeout = skillTimeout;
         ClassUseMode = classUseMode;
         SkillUseMode = skillUseMode;
+        ResetComboOnTargetChange = resetComboOnTargetChange;
     }
 
-    public AdvancedSkill(string className, string skills, int skillTimeout, string classUseMode, SkillUseMode skillUseMode)
+    public AdvancedSkill(string className, string skills, int skillTimeout, string classUseMode, SkillUseMode skillUseMode, bool resetComboOnTargetChange = false)
     {
         ClassName = className;
         Skills = skills;
         SkillTimeout = skillTimeout;
         ClassUseMode = (ClassUseMode)Enum.Parse(typeof(ClassUseMode), classUseMode, ignoreCase: true);
         SkillUseMode = skillUseMode;
+        ResetComboOnTargetChange = resetComboOnTargetChange;
     }
 
     public string ClassName { get; set; } = "Generic";
@@ -46,6 +50,7 @@ public class AdvancedSkill
     public int SkillTimeout { get; set; } = 250;
     public ClassUseMode ClassUseMode { get; set; } = ClassUseMode.Base;
     public SkillUseMode SkillUseMode { get; set; } = SkillUseMode.UseIfAvailable;
+    public bool ResetComboOnTargetChange { get; set; } = false;
     public string SaveString => $"{ClassUseMode} = {ClassName} = {Skills} = {(SkillUseMode == SkillUseMode.UseIfAvailable ? "Use if Available" : SkillTimeout)}";
 
     public override string ToString()

--- a/Skua.Core.Models/Skills/AdvancedSkillJsonModels.cs
+++ b/Skua.Core.Models/Skills/AdvancedSkillJsonModels.cs
@@ -63,6 +63,10 @@ public class SkillModeJson
     [JsonPropertyName("skillTimeout")]
     public int SkillTimeout { get; set; } = 100;
 
+    [JsonPropertyName("resetComboOnTargetChange")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool ResetComboOnTargetChange { get; set; } = false;
+
     [JsonPropertyName("skills")]
     public List<AdvancedSkillJson> Skills { get; set; } = new();
 }

--- a/Skua.Core/Scripts/ScriptSkill.cs
+++ b/Skua.Core/Scripts/ScriptSkill.cs
@@ -263,7 +263,8 @@ public partial class ScriptSkill : IScriptSkill
             }
 
             // target reset if player has no target
-            _provider?.OnTargetReset();
+            if (_provider?.OnTargetReset() == true)
+                continue;
 
             // if the player has target or bot attack without target option is on
             // then activate the skills
@@ -359,7 +360,9 @@ public partial class ScriptSkill : IScriptSkill
                 case SkillUseMode.WaitForCooldown:
                     if (Options.AttackWithoutTarget)
                     {
-                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Using skill {skill} because AttackWithoutTarget is enabled.");
+                        if (ResetComboOnTargetChange)
+                            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Using skill {skill} because AttackWithoutTarget is enabled.");
+
                         this.UseSkill(skill);
                         break;
                     }
@@ -370,7 +373,26 @@ public partial class ScriptSkill : IScriptSkill
                     if (ResetComboOnTargetChange)
                         Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Waiting for skill {skill}. Timeout: {SkillTimeout}, Interval: {SkillInterval}, hasTarget: {Player.HasTarget}");
 
-                    bool canUseAfterWait = Wait.ForTrue(() => CanUseSkill(skill), null, SkillTimeout, SkillInterval);
+                    bool targetReset = false;
+
+                    bool canUseAfterWait = Wait.ForTrue(() =>
+                    {
+                        if (_provider?.OnTargetReset() == true)
+                        {
+                            targetReset = true;
+                            return true;
+                        }
+
+                        return CanUseSkill(skill);
+                    }, null, SkillTimeout, SkillInterval);
+
+                    if (targetReset)
+                    {
+                        if (ResetComboOnTargetChange)
+                            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Aborted wait for skill {skill} because target reset.");
+
+                        return;
+                    }
 
                     if (ResetComboOnTargetChange)
                         Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Finished waiting for skill {skill}. CanUse: {canUseAfterWait}, stopAttacking: {Combat.StopAttacking}, hasTarget: {Player.HasTarget}");

--- a/Skua.Core/Scripts/ScriptSkill.cs
+++ b/Skua.Core/Scripts/ScriptSkill.cs
@@ -72,17 +72,20 @@ public partial class ScriptSkill : IScriptSkill
     public bool TimerRunning { get; private set; } = false;
     public bool IsPaused { get; private set; } = false;
     public int SkillInterval { get; set; } = 100;
-
+    
     public int SkillTimeout { get; set; } = -1;
+
+    public bool ResetComboOnTargetChange { get; set; } = false;
 
     public SkillUseMode SkillUseMode { get; set; } = SkillUseMode.UseIfAvailable;
     private ManualResetEvent _pauseEvent = new(true);
+
 
     public void Start()
     {
         if (BaseProvider is null)
         {
-            BaseProvider = new AdvancedSkillProvider(Player, Self, Target, Combat, Flash);
+            BaseProvider = CreateAdvancedSkillProvider();
             BaseProvider.Load(genericSkills);
             _provider = BaseProvider;
         }
@@ -150,10 +153,10 @@ public partial class ScriptSkill : IScriptSkill
 
     public void LoadAdvanced(string className, bool autoEquip, ClassUseMode useMode = ClassUseMode.Base)
     {
-        OverrideProvider = new AdvancedSkillProvider(Player, Self, Target, Combat, Flash);
-
         if (className == "generic")
         {
+            ResetComboOnTargetChange = false;
+            OverrideProvider = CreateAdvancedSkillProvider();
             OverrideProvider.Load(genericSkills);
             SkillUseMode = SkillUseMode.UseIfAvailable;
             return;
@@ -171,13 +174,21 @@ public partial class ScriptSkill : IScriptSkill
             if (string.Equals(s.ClassName, className, StringComparison.CurrentCultureIgnoreCase))
                 skills.Add(s);
         }
+
         if (skills.Count == 0)
         {
+            ResetComboOnTargetChange = false;
+            OverrideProvider = CreateAdvancedSkillProvider();
             OverrideProvider.Load(genericSkills);
             SkillUseMode = SkillUseMode.UseIfAvailable;
             return;
         }
+
         AdvancedSkill skill = skills.Find(s => s.ClassUseMode == useMode) ?? skills.FirstOrDefault()!;
+
+        ResetComboOnTargetChange = skill.ResetComboOnTargetChange;
+
+        OverrideProvider = CreateAdvancedSkillProvider();
         OverrideProvider.Load(skill.Skills);
         SkillTimeout = skill.SkillTimeout;
         SkillUseMode = skill.SkillUseMode;
@@ -185,7 +196,8 @@ public partial class ScriptSkill : IScriptSkill
 
     public void LoadAdvanced(string skills, int skillTimeout = -1, SkillUseMode skillMode = SkillUseMode.UseIfAvailable)
     {
-        OverrideProvider = new AdvancedSkillProvider(Player, Self, Target, Combat, Flash);
+        ResetComboOnTargetChange = false;
+        OverrideProvider = CreateAdvancedSkillProvider();
         SkillTimeout = skillTimeout;
         SkillUseMode = skillMode;
         OverrideProvider.Load(skills);
@@ -207,14 +219,18 @@ public partial class ScriptSkill : IScriptSkill
                     Inventory.EquipItem(className);
                     Wait.ForItemEquip(className);
                 }
-                OverrideProvider = new AdvancedSkillProvider(Player, Self, Target, Combat, Flash);
+
+                ResetComboOnTargetChange = skill.ResetComboOnTargetChange;
+
+                OverrideProvider = CreateAdvancedSkillProvider();
                 OverrideProvider.Load(skill.Skills);
                 SkillTimeout = skill.SkillTimeout;
                 SkillUseMode = skill.SkillUseMode;
             }
             else
             {
-                OverrideProvider = new AdvancedSkillProvider(Player, Self, Target, Combat, Flash);
+                ResetComboOnTargetChange = false;
+                OverrideProvider = CreateAdvancedSkillProvider();
                 OverrideProvider.Load(genericSkills);
                 SkillUseMode = SkillUseMode.UseIfAvailable;
             }
@@ -350,4 +366,14 @@ public partial class ScriptSkill : IScriptSkill
         if (message.Faded)
             recipient._counterAttack.Set();
     }
+    private AdvancedSkillProvider CreateAdvancedSkillProvider()
+    {
+        return new AdvancedSkillProvider(Player, Self, Target, Combat, Flash)
+        {
+            ResetOnTarget = ResetComboOnTargetChange
+        };
+    }
+
 }
+
+

--- a/Skua.Core/Scripts/ScriptSkill.cs
+++ b/Skua.Core/Scripts/ScriptSkill.cs
@@ -260,15 +260,15 @@ public partial class ScriptSkill : IScriptSkill
                 _provider?.OnPlayerDeath();
             }
 
+            // target reset if player has no target
+            _provider?.OnTargetReset();
+
             // if the player has target or bot attack without target option is on
             // then activate the skills
             if ((Options.AttackWithoutTarget && Player is { Loaded: true, Playing: true }) || Player is { HasTarget: true, Loaded: true, Playing: true })
             {
                 _Poll(token);
             }
-
-            // target reset if player has no target
-            _provider?.OnTargetReset();
 
             // wait for skill interval
             if (!token.IsCancellationRequested)

--- a/Skua.Core/Scripts/ScriptSkill.cs
+++ b/Skua.Core/Scripts/ScriptSkill.cs
@@ -4,8 +4,6 @@ using Skua.Core.Messaging;
 using Skua.Core.Models.Skills;
 using Skua.Core.Skills;
 
-using System.Diagnostics;
-
 namespace Skua.Core.Scripts;
 
 public partial class ScriptSkill : IScriptSkill
@@ -315,9 +313,6 @@ public partial class ScriptSkill : IScriptSkill
         if (index == -1 || skillS == -1)
             return;
 
-        if (ResetComboOnTargetChange)
-            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Next combo index: {index}, skill: {skillS}, mode: {SkillUseMode}, hasTarget: {Player.HasTarget}");
-
         switch (_provider?.ShouldUseSkill(index, CanUseSkill(skillS)))
         {
             case true:
@@ -360,18 +355,12 @@ public partial class ScriptSkill : IScriptSkill
                 case SkillUseMode.WaitForCooldown:
                     if (Options.AttackWithoutTarget)
                     {
-                        if (ResetComboOnTargetChange)
-                            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Using skill {skill} because AttackWithoutTarget is enabled.");
-
                         this.UseSkill(skill);
                         break;
                     }
 
                     if (skill == -1)
                         break;
-
-                    if (ResetComboOnTargetChange)
-                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Waiting for skill {skill}. Timeout: {SkillTimeout}, Interval: {SkillInterval}, hasTarget: {Player.HasTarget}");
 
                     bool targetReset = false;
 
@@ -387,27 +376,10 @@ public partial class ScriptSkill : IScriptSkill
                     }, null, SkillTimeout, SkillInterval);
 
                     if (targetReset)
-                    {
-                        if (ResetComboOnTargetChange)
-                            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Aborted wait for skill {skill} because target reset.");
-
                         return;
-                    }
-
-                    if (ResetComboOnTargetChange)
-                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Finished waiting for skill {skill}. CanUse: {canUseAfterWait}, stopAttacking: {Combat.StopAttacking}, hasTarget: {Player.HasTarget}");
 
                     if (canUseAfterWait && !Combat.StopAttacking)
-                    {
-                        if (ResetComboOnTargetChange)
-                            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Using skill {skill}.");
-
                         this.UseSkill(skill);
-                    }
-                    else if (ResetComboOnTargetChange)
-                    {
-                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Did not use skill {skill}. CanUse: {canUseAfterWait}, stopAttacking: {Combat.StopAttacking}, hasTarget: {Player.HasTarget}");
-                    }
 
                     break;
             }

--- a/Skua.Core/Scripts/ScriptSkill.cs
+++ b/Skua.Core/Scripts/ScriptSkill.cs
@@ -4,6 +4,8 @@ using Skua.Core.Messaging;
 using Skua.Core.Models.Skills;
 using Skua.Core.Skills;
 
+using System.Diagnostics;
+
 namespace Skua.Core.Scripts;
 
 public partial class ScriptSkill : IScriptSkill
@@ -312,6 +314,9 @@ public partial class ScriptSkill : IScriptSkill
         if (index == -1 || skillS == -1)
             return;
 
+        if (ResetComboOnTargetChange)
+            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Next combo index: {index}, skill: {skillS}, mode: {SkillUseMode}, hasTarget: {Player.HasTarget}");
+
         switch (_provider?.ShouldUseSkill(index, CanUseSkill(skillS)))
         {
             case true:
@@ -352,8 +357,36 @@ public partial class ScriptSkill : IScriptSkill
 
                 // if SkillUseMode is WaitForCooldown then use skills with waiting for cooldown
                 case SkillUseMode.WaitForCooldown:
-                    if (Options.AttackWithoutTarget || (skill != -1 && Wait.ForTrue(() => CanUseSkill(skill), null, SkillTimeout, SkillInterval) && !Combat.StopAttacking))
+                    if (Options.AttackWithoutTarget)
+                    {
+                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Using skill {skill} because AttackWithoutTarget is enabled.");
                         this.UseSkill(skill);
+                        break;
+                    }
+
+                    if (skill == -1)
+                        break;
+
+                    if (ResetComboOnTargetChange)
+                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Waiting for skill {skill}. Timeout: {SkillTimeout}, Interval: {SkillInterval}, hasTarget: {Player.HasTarget}");
+
+                    bool canUseAfterWait = Wait.ForTrue(() => CanUseSkill(skill), null, SkillTimeout, SkillInterval);
+
+                    if (ResetComboOnTargetChange)
+                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Finished waiting for skill {skill}. CanUse: {canUseAfterWait}, stopAttacking: {Combat.StopAttacking}, hasTarget: {Player.HasTarget}");
+
+                    if (canUseAfterWait && !Combat.StopAttacking)
+                    {
+                        if (ResetComboOnTargetChange)
+                            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Using skill {skill}.");
+
+                        this.UseSkill(skill);
+                    }
+                    else if (ResetComboOnTargetChange)
+                    {
+                        Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [ScriptSkill] Did not use skill {skill}. CanUse: {canUseAfterWait}, stopAttacking: {Combat.StopAttacking}, hasTarget: {Player.HasTarget}");
+                    }
+
                     break;
             }
         }

--- a/Skua.Core/Skills/AdvancedSkillContainer.cs
+++ b/Skua.Core/Skills/AdvancedSkillContainer.cs
@@ -141,7 +141,8 @@ public class AdvancedSkillContainer : ObservableRecipient, IAdvancedSkillContain
                         skillsStr,
                         skillMode.SkillTimeout,
                         classUseMode,
-                        skillMode.SkillUseMode == "UseIfAvailable" ? SkillUseMode.UseIfAvailable : SkillUseMode.WaitForCooldown
+                        skillMode.SkillUseMode == "UseIfAvailable" ? SkillUseMode.UseIfAvailable : SkillUseMode.WaitForCooldown,
+                        skillMode.ResetComboOnTargetChange
                     ));
                 }
             }
@@ -318,6 +319,7 @@ public class AdvancedSkillContainer : ObservableRecipient, IAdvancedSkillContain
             {
                 SkillUseMode = skill.SkillUseMode == SkillUseMode.UseIfAvailable ? "UseIfAvailable" : "WaitForCooldown",
                 SkillTimeout = skill.SkillTimeout,
+                ResetComboOnTargetChange = skill.ResetComboOnTargetChange,
                 Skills = AdvancedSkillsParser.ParseSkillString(skill.Skills)
             };
 

--- a/Skua.Core/Skills/AdvancedSkillProvider.cs
+++ b/Skua.Core/Skills/AdvancedSkillProvider.cs
@@ -1,6 +1,8 @@
 using Skua.Core.Interfaces;
 using Skua.Core.Models.Monsters;
 
+using System.Diagnostics;
+
 namespace Skua.Core.Skills;
 
 public class AdvancedSkillProvider : ISkillProvider
@@ -350,6 +352,7 @@ public class AdvancedSkillProvider : ISkillProvider
         {
             if (_lastTargetKey != null)
             {
+                Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Target lost. Last target was [{_lastTargetKey}]. Resetting combo.");
                 _lastTargetKey = null;
                 _currentCommand.Reset();
             }
@@ -360,11 +363,13 @@ public class AdvancedSkillProvider : ISkillProvider
         if (_lastTargetKey == null)
         {
             _lastTargetKey = currentTargetKey;
+            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Initial target set to [{currentTargetKey}].");
             return;
         }
 
         if (!string.Equals(_lastTargetKey, currentTargetKey, StringComparison.Ordinal))
         {
+            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Target changed from [{_lastTargetKey}] to [{currentTargetKey}]. Resetting combo.");
             _lastTargetKey = currentTargetKey;
             _currentCommand.Reset();
         }

--- a/Skua.Core/Skills/AdvancedSkillProvider.cs
+++ b/Skua.Core/Skills/AdvancedSkillProvider.cs
@@ -24,6 +24,7 @@ public class AdvancedSkillProvider : ISkillProvider
     private readonly UseRule[] _none = new[] { new UseRule(SkillRule.None) };
 
     public bool ResetOnTarget { get; set; } = false;
+    private string? _lastTargetKey;
     public int SkillCount => _currentCommand.SkillCount;
 
     public (int, int) GetNextSkill()
@@ -339,8 +340,41 @@ public class AdvancedSkillProvider : ISkillProvider
 
     public void OnTargetReset()
     {
-        if (ResetOnTarget && !_player.HasTarget)
+        if (!ResetOnTarget)
+            return;
+
+        if (!_player.HasTarget)
+        {
+            if (_lastTargetKey != null)
+            {
+                _lastTargetKey = null;
+                _currentCommand.Reset();
+            }
+
+            return;
+        }
+
+        string currentTargetKey = GetCurrentTargetKey();
+
+        if (_lastTargetKey == null)
+        {
+            _lastTargetKey = currentTargetKey;
+            return;
+        }
+
+        if (!string.Equals(_lastTargetKey, currentTargetKey, StringComparison.Ordinal))
+        {
+            _lastTargetKey = currentTargetKey;
             _currentCommand.Reset();
+        }
+    }
+
+    private string GetCurrentTargetKey() //temporary, will replace when i can find a better way to do this
+    {
+        string targetName = _player.Target?.Name ?? string.Empty;
+        int targetHp = _player.Target?.HP ?? -1;
+
+        return $"{targetName}:{targetHp}";
     }
 
     public bool? ShouldUseSkill(int skillIndex, bool canUse)
@@ -352,11 +386,13 @@ public class AdvancedSkillProvider : ISkillProvider
     {
         _combat.CancelAutoAttack();
         _combat.CancelTarget();
+        _lastTargetKey = null;
         _currentCommand.Reset();
     }
 
     public void OnPlayerDeath()
     {
+        _lastTargetKey = null;
         _currentCommand.Reset();
     }
 }

--- a/Skua.Core/Skills/AdvancedSkillProvider.cs
+++ b/Skua.Core/Skills/AdvancedSkillProvider.cs
@@ -1,8 +1,6 @@
 using Skua.Core.Interfaces;
 using Skua.Core.Models.Monsters;
 
-using System.Diagnostics;
-
 namespace Skua.Core.Skills;
 
 public class AdvancedSkillProvider : ISkillProvider
@@ -352,7 +350,6 @@ public class AdvancedSkillProvider : ISkillProvider
         {
             if (_lastTargetKey != null)
             {
-                Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Target lost. Last target was [{_lastTargetKey}]. Resetting combo.");
                 _lastTargetKey = null;
                 _currentCommand.Reset();
                 return true;
@@ -364,13 +361,11 @@ public class AdvancedSkillProvider : ISkillProvider
         if (_lastTargetKey == null)
         {
             _lastTargetKey = currentTargetKey;
-            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Initial target set to [{currentTargetKey}].");
             return false;
         }
 
         if (!string.Equals(_lastTargetKey, currentTargetKey, StringComparison.Ordinal))
         {
-            Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Target changed from [{_lastTargetKey}] to [{currentTargetKey}]. Resetting combo.");
             _lastTargetKey = currentTargetKey;
             _currentCommand.Reset();
             return true;

--- a/Skua.Core/Skills/AdvancedSkillProvider.cs
+++ b/Skua.Core/Skills/AdvancedSkillProvider.cs
@@ -1,4 +1,5 @@
 using Skua.Core.Interfaces;
+using Skua.Core.Models.Monsters;
 
 namespace Skua.Core.Skills;
 
@@ -343,7 +344,9 @@ public class AdvancedSkillProvider : ISkillProvider
         if (!ResetOnTarget)
             return;
 
-        if (!_player.HasTarget)
+        string? currentTargetKey = _player.HasTarget ? GetCurrentTargetKey() : null;
+
+        if (currentTargetKey == null)
         {
             if (_lastTargetKey != null)
             {
@@ -353,8 +356,6 @@ public class AdvancedSkillProvider : ISkillProvider
 
             return;
         }
-
-        string currentTargetKey = GetCurrentTargetKey();
 
         if (_lastTargetKey == null)
         {
@@ -369,12 +370,14 @@ public class AdvancedSkillProvider : ISkillProvider
         }
     }
 
-    private string GetCurrentTargetKey() //temporary, will replace when i can find a better way to do this
+    private string? GetCurrentTargetKey()
     {
-        string targetName = _player.Target?.Name ?? string.Empty;
-        int targetHp = _player.Target?.HP ?? -1;
+        Monster? target = _player.Target;
 
-        return $"{targetName}:{targetHp}";
+        if (target == null)
+            return null;
+
+        return $"{target.MapID}:{target.ID}:{target.Cell}:{target.Name}";
     }
 
     public bool? ShouldUseSkill(int skillIndex, bool canUse)

--- a/Skua.Core/Skills/AdvancedSkillProvider.cs
+++ b/Skua.Core/Skills/AdvancedSkillProvider.cs
@@ -341,10 +341,10 @@ public class AdvancedSkillProvider : ISkillProvider
     {
     }
 
-    public void OnTargetReset()
+    public bool OnTargetReset()
     {
         if (!ResetOnTarget)
-            return;
+            return false;
 
         string? currentTargetKey = _player.HasTarget ? GetCurrentTargetKey() : null;
 
@@ -355,16 +355,17 @@ public class AdvancedSkillProvider : ISkillProvider
                 Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Target lost. Last target was [{_lastTargetKey}]. Resetting combo.");
                 _lastTargetKey = null;
                 _currentCommand.Reset();
+                return true;
             }
 
-            return;
+            return false;
         }
 
         if (_lastTargetKey == null)
         {
             _lastTargetKey = currentTargetKey;
             Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Initial target set to [{currentTargetKey}].");
-            return;
+            return false;
         }
 
         if (!string.Equals(_lastTargetKey, currentTargetKey, StringComparison.Ordinal))
@@ -372,7 +373,10 @@ public class AdvancedSkillProvider : ISkillProvider
             Trace.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [AdvSkillProvider] Target changed from [{_lastTargetKey}] to [{currentTargetKey}]. Resetting combo.");
             _lastTargetKey = currentTargetKey;
             _currentCommand.Reset();
+            return true;
         }
+
+        return false;
     }
 
     private string? GetCurrentTargetKey()

--- a/Skua.Core/ViewModels/AdvancedSkills/AdvancedSkillEditorViewModel.cs
+++ b/Skua.Core/ViewModels/AdvancedSkills/AdvancedSkillEditorViewModel.cs
@@ -46,6 +46,9 @@ public partial class AdvancedSkillEditorViewModel : ObservableRecipient
     [ObservableProperty]
     private string _currentClassName = string.Empty;
 
+    [ObservableProperty]
+    private bool _resetComboOnTargetChange;
+
     public string[] ClassUseModes { get; }
     public SkillRulesViewModel UseRules { get; }
     public IRelayCommand ClearSkillsCommand { get; }
@@ -68,7 +71,7 @@ public partial class AdvancedSkillEditorViewModel : ObservableRecipient
             skillStrings.Add(skill.Convert());
         string skills = string.Join(" | ", skillStrings);
         string modeString = SelectedClassUseMode >= 0 && SelectedClassUseMode < ClassUseModes.Length ? ClassUseModes[SelectedClassUseMode] : "Base";
-        AdvancedSkill advSkill = new(CurrentClassName, skills, CurrentSkillTimeout, modeString, UseWaitModeBool ? SkillUseMode.WaitForCooldown : SkillUseMode.UseIfAvailable);
+        AdvancedSkill advSkill = new(CurrentClassName, skills, CurrentSkillTimeout, modeString, UseWaitModeBool ? SkillUseMode.WaitForCooldown : SkillUseMode.UseIfAvailable, ResetComboOnTargetChange);
         OnPropertyChanged(nameof(CurrentSkillsList));
         Messenger.Send<SaveAdvancedSkillMessage>(new(advSkill));
     }
@@ -155,6 +158,7 @@ public partial class AdvancedSkillEditorViewModel : ObservableRecipient
         recipient.CurrentSkillsList.Clear();
         recipient.CurrentSkillTimeout = message.AdvSkill.SkillTimeout;
         recipient.UseWaitModeBool = message.AdvSkill.SkillUseMode != SkillUseMode.UseIfAvailable;
+        recipient.ResetComboOnTargetChange = message.AdvSkill.ResetComboOnTargetChange;
         recipient.CurrentClassName = message.AdvSkill.ClassName;
         recipient.SelectedClassUseMode = (int)message.AdvSkill.ClassUseMode;
         recipient.CurrentSkillsList.AddRange(message.AdvSkill.Skills.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(s => new SkillItemViewModel(s.Trim())));

--- a/Skua.WPF/UserControls/AdvancedSkillEditorUserControl.xaml
+++ b/Skua.WPF/UserControls/AdvancedSkillEditorUserControl.xaml
@@ -30,22 +30,22 @@
             Grid.Column="0"
             Margin="6,6,3,3"
             Header="Set SkillTimeout">
-            <TextBox
-                Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Margin="3"
-                materialDesign:HintAssist.Hint="SkillTimeout"
-                Text="{Binding CurrentSkillTimeout, UpdateSourceTrigger=PropertyChanged}">
-                <TextBox.ToolTip>
-                    <TextBlock>
-                        The maximum time it will wait for a skill in multiples of the SkillTimer (default 100ms). Default SkillTimeout is 100 (10000 ms).<LineBreak />
-                        Note that the skill timeout is only used when Wait for Cooldown is enable.</TextBlock>
-                </TextBox.ToolTip>
-                <b:Interaction.Behaviors>
-                    <wpf:TextBoxOnlyNumbersBehavior />
-                </b:Interaction.Behaviors>
-            </TextBox>
+            <Grid VerticalAlignment="Center">
+                <TextBox
+                    Margin="3"
+                    materialDesign:HintAssist.Hint="SkillTimeout"
+                    Text="{Binding CurrentSkillTimeout, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.ToolTip>
+                        <TextBlock>
+                            The maximum time it will wait for a skill in multiples of the SkillTimer (default 100ms). Default SkillTimeout is 100 (10000 ms).<LineBreak />
+                            Note that the skill timeout is only used when Wait for Cooldown is enable.
+                        </TextBlock>
+                    </TextBox.ToolTip>
+                    <b:Interaction.Behaviors>
+                        <wpf:TextBoxOnlyNumbersBehavior />
+                    </b:Interaction.Behaviors>
+                </TextBox>
+            </Grid>
         </GroupBox>
         <!--#endregion-->
 
@@ -95,8 +95,8 @@
                     IsChecked="{Binding ResetComboOnTargetChange}">
                     <CheckBox.ToolTip>
                         <TextBlock>
-                Restarts the advanced skill combo from the beginning when the current target dies, disappears, or changes.<LineBreak />
-                Useful for classes whose combo depends on autoattack timing.</TextBlock>
+                            Restarts the advanced skill combo from the beginning when the current target dies, disappears, or changes.<LineBreak />
+                            Useful for classes whose combo depends on autoattack timing.</TextBlock>
                     </CheckBox.ToolTip>
                 </CheckBox>
             </Grid>

--- a/Skua.WPF/UserControls/AdvancedSkillEditorUserControl.xaml
+++ b/Skua.WPF/UserControls/AdvancedSkillEditorUserControl.xaml
@@ -60,6 +60,10 @@
                     <ColumnDefinition />
                     <ColumnDefinition />
                 </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
                 <CheckBox
                     Grid.Column="0"
                     Margin="3"
@@ -81,6 +85,20 @@
                     Content="Use if Available"
                     IsChecked="{Binding UseWaitModeBool, Converter={StaticResource InvertBooleanConverter}}"
                     ToolTip="Whenever a skill is available it will be used, if it is not then it will be skipped" />
+                <CheckBox
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Margin="3"
+                    HorizontalAlignment="Stretch"
+                    materialDesign:CheckBoxAssist.CheckBoxSize="25"
+                    Content="Reset on Target Change"
+                    IsChecked="{Binding ResetComboOnTargetChange}">
+                    <CheckBox.ToolTip>
+                        <TextBlock>
+                Restarts the advanced skill combo from the beginning when the current target dies, disappears, or changes.<LineBreak />
+                Useful for classes whose combo depends on autoattack timing.</TextBlock>
+                    </CheckBox.ToolTip>
+                </CheckBox>
             </Grid>
         </GroupBox>
         <!--#endregion-->


### PR DESCRIPTION
added this feature in the issues list -> https://github.com/auqw/Skua/issues/30

It works via looking at the current selected targets MapID, ID, Cell, and Name, and then when any target is lost or changes, the skillset is reset back to the start.

Its really only usable in **WaitForCooldown** (strict combo usage) due to how UseIfAvailable (use off cooldown) works.

## Summary by Sourcery

Add support for resetting advanced skill combos when the target changes and propagate this option through skills configuration, editor UI, and runtime execution.

New Features:
- Introduce a ResetComboOnTargetChange option on advanced skills that resets the combo when the selected target changes or is lost.
- Expose the reset-on-target-change flag in the advanced skills JSON model and WPF editor so it can be configured per class/mode.

Enhancements:
- Update the skill execution flow and AdvancedSkillProvider to track target identity and reset command state only when the target actually changes or is cleared.
- Refine WaitForCooldown behavior to respect combo reset when the target changes during cooldown waits.